### PR TITLE
Remove cell reload on viewWillAppear. Fixes #23

### DIFF
--- a/FiveCalls/FiveCalls/IssuesViewController.swift
+++ b/FiveCalls/FiveCalls/IssuesViewController.swift
@@ -29,6 +29,10 @@ class IssuesViewController : UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         // NotificationCenter.default.addObserver(self, selector: #selector(locationChanged(_:)), name: .locationChanged, object: nil)
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
         tableView.reloadRows(at: tableView.indexPathsForVisibleRows ?? [], with: .none)
     }
 


### PR DESCRIPTION
Removes what appears to be an unnecessary `reloadRows` call on `viewWillAppear`. @subdigital agreed that it seemed unnecessary. This call was causing rows to be reloaded when detail view controllers were popped and seemed to cause layout issues.