### PR TITLE
#42 - About Screen: Social Links don't unselect

### DIFF
--- a/FiveCalls/FiveCalls/AboutViewController.swift
+++ b/FiveCalls/FiveCalls/AboutViewController.swift
@@ -51,6 +51,7 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
             
         default: break;
         }
+        tableView.deselectRow(at: indexPath, animated: true)
     }
     
     func sendFeedback() {


### PR DESCRIPTION
Deselects the selected tableViewCell after performing designated action.