### PR TITLE
Fixes crash when scrolling to bottom of table view

### DIFF
--- a/FiveCalls/FiveCalls/IssueDetailViewController.swift
+++ b/FiveCalls/FiveCalls/IssueDetailViewController.swift
@@ -146,8 +146,10 @@ extension IssueDetailViewController : UITableViewDataSource {
     }
     
     func scrollToBottom() {
-        let lastIndexPath = IndexPath(row: issue.contacts.count - 1, section: IssueSections.contacts.rawValue)
-        self.tableView.scrollToRow(at: lastIndexPath, at: .bottom, animated: true)
+        let s = self.tableView.contentSize
+        var b = self.tableView.bounds
+        b.origin.y = max(0,s.height - b.height)
+        self.tableView.scrollRectToVisible(b, animated: true)
     }
 }
 


### PR DESCRIPTION
I'm pretty sure my Swift is right for this case - basically just changes to use a target rect to scroll to instead of an index path. There's rare edge cases that might build an invalid index path, and this gets around any edge cases by always scrolling to the bottom-most rect of a table's contents.

Fixes #44 