### PR TITLE
Match the font for the Done button in the location view controller

### DIFF
--- a/FiveCalls/FiveCalls/EditLocationViewController.swift
+++ b/FiveCalls/FiveCalls/EditLocationViewController.swift
@@ -35,7 +35,6 @@ class EditLocationViewController : UIViewController, CLLocationManagerDelegate {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.navigationBar.tintColor = .white
         zipCodeTextField.becomeFirstResponder()
         
         if case .zipCode? = UserLocation.current.locationType {


### PR DESCRIPTION
Not sure why the tintColor reverts the other style changes in UIAppearance, but removing that manual tint color lets the appearance take over, matching the correct font in the Done button.