### PR TITLE
Resolve new swift 3.1 warnings

### DIFF
--- a/FiveCalls/FiveCalls/IssuesManager.swift
+++ b/FiveCalls/FiveCalls/IssuesManager.swift
@@ -34,7 +34,7 @@ class IssuesManager {
                     completion()
                 }
             } else {
-                print("Could not load issues.. \(operation.error?.localizedDescription)")
+                print("Could not load issues.. \(operation.error?.localizedDescription ?? "[operation error was nil]")")
             }
         }
         OperationQueue.main.addOperation(operation)

--- a/FiveCalls/FiveCalls/RemoteImageView.swift
+++ b/FiveCalls/FiveCalls/RemoteImageView.swift
@@ -36,7 +36,7 @@ class RemoteImageView : UIImageView {
         currentTask = session.dataTask(with: url, completionHandler: { (data, response, error) in
             guard self.currentTask!.state != .canceling else { return }
             
-            if let e = error as? NSError {
+            if let e = error as NSError? {
                 if e.domain == NSURLErrorDomain && e.code == NSURLErrorCancelled {
                     // ignore cancellation errors
                 } else {


### PR DESCRIPTION
This resolves a couple new warnings related to optionality in swift 3.1 / Xcode 8.3; builds fine in 3.0 as well.