### PR TITLE
#59 Fixed the image flashing in the `IssueDetailViewController` avatars

### DIFF
--- a/FiveCalls/FiveCalls/IssueDetailViewController.swift
+++ b/FiveCalls/FiveCalls/IssueDetailViewController.swift
@@ -15,7 +15,8 @@ class IssueDetailViewController : UIViewController, IssueShareable {
     var issuesManager: IssuesManager!
     var issue: Issue!
     var logs: ContactLogs?
-    
+    internal var images = [String: UIImage]()
+
     @IBOutlet weak var tableView: UITableView!
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -111,7 +112,8 @@ extension IssueDetailViewController : UITableViewDataSource {
                 cell.nameLabel.text = contact.name
                 cell.subtitleLabel.text = contact.area
                 if let photoURL = contact.photoURL {
-                    cell.avatarImageView.setRemoteImage(url: photoURL)
+                    let imageKey = photoURL.absoluteString
+                    cell.avatarImageView.setRemoteImage(preferred: images[imageKey], url: photoURL, completion:  { self.images[imageKey] = $0 })
                 } else {
                     cell.avatarImageView.image = cell.avatarImageView.defaultImage
                 }

--- a/FiveCalls/FiveCalls/IssueDetailViewController.swift
+++ b/FiveCalls/FiveCalls/IssueDetailViewController.swift
@@ -15,8 +15,7 @@ class IssueDetailViewController : UIViewController, IssueShareable {
     var issuesManager: IssuesManager!
     var issue: Issue!
     var logs: ContactLogs?
-    internal var images = [String: UIImage]()
-
+    
     @IBOutlet weak var tableView: UITableView!
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -112,8 +111,7 @@ extension IssueDetailViewController : UITableViewDataSource {
                 cell.nameLabel.text = contact.name
                 cell.subtitleLabel.text = contact.area
                 if let photoURL = contact.photoURL {
-                    let imageKey = photoURL.absoluteString
-                    cell.avatarImageView.setRemoteImage(preferred: images[imageKey], url: photoURL, completion:  { self.images[imageKey] = $0 })
+                    cell.avatarImageView.setRemoteImage(url: photoURL)
                 } else {
                     cell.avatarImageView.image = cell.avatarImageView.defaultImage
                 }

--- a/FiveCalls/FiveCalls/RemoteImageView.swift
+++ b/FiveCalls/FiveCalls/RemoteImageView.swift
@@ -32,6 +32,14 @@ class RemoteImageView : UIImageView {
     
     func setRemoteImage(url: URL, completion: @escaping RemoteImageCallback) {
         image = defaultImage
+        setRemoteImage(preferred: defaultImage, url: url, completion: completion)
+    }
+
+    func setRemoteImage(preferred preferredImage: UIImage?, url: URL, completion: @escaping RemoteImageCallback) {
+        image = preferredImage
+        guard preferredImage == nil || preferredImage == defaultImage else {
+            return completion(preferredImage!)
+        }
         currentTask?.cancel()
         currentTask = session.dataTask(with: url, completionHandler: { (data, response, error) in
             guard self.currentTask!.state != .canceling else { return }

--- a/FiveCalls/FiveCalls/RemoteImageView.swift
+++ b/FiveCalls/FiveCalls/RemoteImageView.swift
@@ -31,11 +31,15 @@ class RemoteImageView : UIImageView {
     }
     
     func setRemoteImage(url: URL, completion: @escaping RemoteImageCallback) {
-        image = defaultImage
         setRemoteImage(preferred: defaultImage, url: url, completion: completion)
     }
 
     func setRemoteImage(preferred preferredImage: UIImage?, url: URL, completion: @escaping RemoteImageCallback) {
+        if let cachedImage = ImageCache.shared.image(forKey: url) {
+            image = cachedImage
+            return
+        }
+        
         image = preferredImage
         guard preferredImage == nil || preferredImage == defaultImage else {
             return completion(preferredImage!)
@@ -56,6 +60,7 @@ class RemoteImageView : UIImageView {
                 if http.statusCode == 200 {
                     if let data = data, let image = UIImage(data: data) {
                         self.currentImageURL = url
+                        ImageCache.shared.set(image: image, forKey: url)
                         DispatchQueue.main.async {
                             completion(image)
                         }
@@ -67,4 +72,24 @@ class RemoteImageView : UIImageView {
         })
         currentTask?.resume()
     }
+}
+
+private struct ImageCache {
+    static var shared = ImageCache()
+    
+    private let cache: NSCache<NSString, UIImage>
+    
+    init() {
+        cache = NSCache()
+    }
+    
+    func image(forKey key:URL) -> UIImage? {
+        return cache.object(forKey: key.absoluteString as NSString)
+    }
+    
+    func set(image: UIImage, forKey key: URL) {
+        cache.setObject(image, forKey: key.absoluteString as NSString)
+    }
+    
+    
 }


### PR DESCRIPTION
https://github.com/5calls/ios/issues/59

This solution is memory only, and is local to this `IssueDetailViewController`, but could be moved to a singleton/app delegate.
Or, conversely, we could use an existing cache solution. However, this seems like a small thing to pull in another dependency for.

*  `[String: UIImage]` property to `IssueDetailViewController`
    * check it when setting `cell.avatarImageView.image`
    * or set it after downloading remote image
* added `setRemoteImage` method with a "preferredImage" argument