### PR TITLE
#55 - Smaller Screen Issues

### DIFF
--- a/FiveCalls/FiveCalls/AppearanceProxies.swift
+++ b/FiveCalls/FiveCalls/AppearanceProxies.swift
@@ -21,6 +21,9 @@ extension UILabel {
             
             if let descriptor = UIFontDescriptor(fontAttributes: newValue.fontAttributes).withSymbolicTraits(symbolicTraits) {
                 self.font = UIFont(descriptor: descriptor, size: font.pointSize)
+            } else {
+                // Fixes issue with iOS 9 not getting the custom font but may lose traits this way
+                self.font = UIFont(descriptor: newValue, size: font.pointSize)
             }
         }
     }

--- a/FiveCalls/FiveCalls/Base.lproj/Welcome.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Welcome.storyboard
@@ -22,7 +22,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="5calls-logotype" translatesAutoresizingMaskIntoConstraints="NO" id="5OW-04-u8c">
-                                <rect key="frame" x="41.5" y="28" width="292" height="158"/>
+                                <rect key="frame" x="42" y="28" width="292" height="158"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="292" id="248-fw-pMH"/>
                                 </constraints>
@@ -144,7 +144,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Hra-Uy-7K6">
-                                <rect key="frame" x="24" y="154" width="327" height="42.5"/>
+                                <rect key="frame" x="24" y="154" width="327" height="43"/>
                                 <string key="text">TOGETHER WE'VE MADE 
 ... CALLS</string>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>

--- a/FiveCalls/FiveCalls/Base.lproj/Welcome.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Welcome.storyboard
@@ -4,7 +4,6 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -23,7 +22,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="5calls-logotype" translatesAutoresizingMaskIntoConstraints="NO" id="5OW-04-u8c">
-                                <rect key="frame" x="41" y="28" width="292" height="158"/>
+                                <rect key="frame" x="41.5" y="28" width="292" height="158"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="292" id="248-fw-pMH"/>
                                 </constraints>
@@ -73,13 +72,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MAKE YOUR VOICE HEARD" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eV6-4Q-3q1">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MAKE YOUR VOICE HEARD" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="eV6-4Q-3q1">
                                 <rect key="frame" x="24" y="24" width="327" height="67.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" red="0.094117647058823528" green="0.45882352941176469" blue="0.81960784313725488" alpha="1" colorSpace="deviceRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gTN-TQ-Ssn">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gTN-TQ-Ssn">
                                 <rect key="frame" x="24" y="111.5" width="327" height="108.5"/>
                                 <string key="text">Turn your passive participation into active resistance. Facebook likes and Twitter retweets can’t create the change you want to see. Calling your Government on the phone can.</string>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
@@ -121,13 +120,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Spend 5 minutes, make 5 calls." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1HS-eY-5Py">
-                                <rect key="frame" x="24" y="44" width="327" height="67.5"/>
+                                <rect key="frame" x="24" y="24" width="327" height="67.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" red="0.094117647058823528" green="0.45882352941176469" blue="0.81960784313725488" alpha="1" colorSpace="deviceRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FL3-kO-5GT" customClass="BlueButton" customModule="FiveCalls" customModuleProvider="target">
-                                <rect key="frame" x="24" y="570" width="327" height="73"/>
+                                <rect key="frame" x="24" y="580" width="327" height="73"/>
                                 <color key="backgroundColor" red="0.09546948224" green="0.45810282229999999" blue="0.81936717029999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="73" id="yc3-dU-J9N"/>
@@ -144,16 +143,16 @@
                                     <action selector="getStartedTapped:" destination="fyU-dq-yax" eventType="touchUpInside" id="VfR-lg-kWZ"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hra-Uy-7K6">
-                                <rect key="frame" x="24" y="189.5" width="327" height="42.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Hra-Uy-7K6">
+                                <rect key="frame" x="24" y="154" width="327" height="42.5"/>
                                 <string key="text">TOGETHER WE'VE MADE 
 ... CALLS</string>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="textColor" red="0.094119999999999995" green="0.45882000000000001" blue="0.81960999999999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Calling is the most effective way to influence your representative." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QTT-YD-26Z">
-                                <rect key="frame" x="24" y="123" width="327" height="42.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Calling is the most effective way to influence your representative." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="QTT-YD-26Z">
+                                <rect key="frame" x="24" y="101.5" width="327" height="42.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <color key="textColor" red="0.094119999999999995" green="0.45882000000000001" blue="0.81960999999999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -165,24 +164,29 @@
                             <constraint firstItem="1HS-eY-5Py" firstAttribute="leading" secondItem="ht3-ki-psO" secondAttribute="leading" constant="24" id="Dok-6W-bbL"/>
                             <constraint firstItem="1HS-eY-5Py" firstAttribute="top" secondItem="Ne5-Ii-gp0" secondAttribute="bottom" constant="24" id="Mah-SM-w9f"/>
                             <constraint firstItem="Hra-Uy-7K6" firstAttribute="leading" secondItem="1HS-eY-5Py" secondAttribute="leading" id="Q3g-bL-kZB"/>
-                            <constraint firstItem="QTT-YD-26Z" firstAttribute="top" secondItem="1HS-eY-5Py" secondAttribute="bottom" constant="11.5" id="XGQ-ct-r79"/>
+                            <constraint firstItem="QTT-YD-26Z" firstAttribute="top" secondItem="1HS-eY-5Py" secondAttribute="bottom" constant="10" id="XGQ-ct-r79"/>
                             <constraint firstItem="FL3-kO-5GT" firstAttribute="leading" secondItem="ht3-ki-psO" secondAttribute="leadingMargin" constant="8" id="bWK-VM-XRv"/>
                             <constraint firstItem="QTT-YD-26Z" firstAttribute="trailing" secondItem="1HS-eY-5Py" secondAttribute="trailing" id="da8-CL-ScH"/>
                             <constraint firstAttribute="trailing" secondItem="1HS-eY-5Py" secondAttribute="trailing" constant="24" id="hqn-jR-rep"/>
                             <constraint firstItem="QTT-YD-26Z" firstAttribute="leading" secondItem="1HS-eY-5Py" secondAttribute="leading" id="iqV-RR-C0M"/>
                             <constraint firstAttribute="trailingMargin" secondItem="FL3-kO-5GT" secondAttribute="trailing" constant="8" id="kEf-zp-aA2"/>
-                            <constraint firstItem="Hra-Uy-7K6" firstAttribute="top" secondItem="QTT-YD-26Z" secondAttribute="bottom" constant="24" id="nJF-bp-aA4"/>
-                            <constraint firstItem="FL3-kO-5GT" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Hra-Uy-7K6" secondAttribute="bottom" constant="24" id="r1q-fQ-bhS"/>
-                            <constraint firstItem="rXb-W1-5JO" firstAttribute="top" secondItem="FL3-kO-5GT" secondAttribute="bottom" constant="24" id="zhQ-tU-Y1Y"/>
+                            <constraint firstItem="Hra-Uy-7K6" firstAttribute="top" secondItem="QTT-YD-26Z" secondAttribute="bottom" constant="10" id="nJF-bp-aA4"/>
+                            <constraint firstItem="FL3-kO-5GT" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Hra-Uy-7K6" secondAttribute="bottom" constant="4" id="r1q-fQ-bhS"/>
+                            <constraint firstItem="rXb-W1-5JO" firstAttribute="top" secondItem="FL3-kO-5GT" secondAttribute="bottom" constant="14" id="zhQ-tU-Y1Y"/>
                         </constraints>
                     </view>
+                    <nil key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
                     <connections>
+                        <outlet property="bottomMargin" destination="zhQ-tU-Y1Y" id="5ls-GO-vsS"/>
+                        <outlet property="buttonHeight" destination="yc3-dU-J9N" id="V07-bQ-UMV"/>
                         <outlet property="label" destination="Hra-Uy-7K6" id="QsR-sM-Nx3"/>
+                        <outlet property="topMargin" destination="Mah-SM-w9f" id="Fyx-ov-jKr"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dYP-gV-ILJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1357.5999999999999" y="123.68815592203899"/>
+            <point key="canvasLocation" x="1280" y="123"/>
         </scene>
     </scenes>
     <resources>

--- a/FiveCalls/FiveCalls/Main.storyboard
+++ b/FiveCalls/FiveCalls/Main.storyboard
@@ -169,9 +169,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Be-hS-t4B" customClass="BlueButton" customModule="FiveCalls" customModuleProvider="target">
-                                <rect key="frame" x="60" y="15" width="294" height="44"/>
+                                <rect key="frame" x="72.666666666666686" y="15" width="270" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="HAO-vV-2NC"/>
+                                    <constraint firstAttribute="width" constant="270" id="Pdf-nI-tIb"/>
                                 </constraints>
                                 <state key="normal" title="Use My Location"/>
                                 <userDefinedRuntimeAttributes>
@@ -189,13 +190,6 @@
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Czh-eH-GW2">
-                                <rect key="frame" x="298" y="27" width="20" height="20"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="20" id="Cmb-88-OrV"/>
-                                    <constraint firstAttribute="height" constant="20" id="RyP-Pd-DBq"/>
-                                </constraints>
-                            </activityIndicatorView>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Zip Code" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8JR-Y0-Fwm">
                                 <rect key="frame" x="44" y="110" width="220" height="55"/>
                                 <constraints>
@@ -221,6 +215,13 @@
                                     <action selector="submitZipCodeTapped:" destination="mvc-KU-4ug" eventType="touchUpInside" id="zWm-0b-uhZ"/>
                                 </connections>
                             </button>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Czh-eH-GW2">
+                                <rect key="frame" x="310" y="27" width="20" height="20"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="20" id="Cmb-88-OrV"/>
+                                    <constraint firstAttribute="height" constant="20" id="RyP-Pd-DBq"/>
+                                </constraints>
+                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -229,13 +230,11 @@
                             <constraint firstItem="5Be-hS-t4B" firstAttribute="top" secondItem="Et2-qp-YNn" secondAttribute="bottom" constant="15" id="4T8-uL-Dh5"/>
                             <constraint firstItem="8JR-Y0-Fwm" firstAttribute="top" secondItem="7Xf-pd-kKj" secondAttribute="bottom" constant="15" id="7A2-4j-2Kd"/>
                             <constraint firstAttribute="trailingMargin" secondItem="S0o-QZ-kcL" secondAttribute="trailing" constant="24" id="BD1-tr-VbL"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="5Be-hS-t4B" secondAttribute="trailing" constant="40" id="Bel-jv-IRK"/>
                             <constraint firstItem="5Be-hS-t4B" firstAttribute="centerX" secondItem="KQU-J2-YtO" secondAttribute="centerX" id="E3V-Vx-8rH"/>
                             <constraint firstItem="S0o-QZ-kcL" firstAttribute="leading" secondItem="8JR-Y0-Fwm" secondAttribute="trailing" constant="6" id="Jvz-Vm-DCI"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="Czh-eH-GW2" secondAttribute="trailing" constant="76" id="M3Q-bK-g0j"/>
-                            <constraint firstItem="5Be-hS-t4B" firstAttribute="leading" secondItem="KQU-J2-YtO" secondAttribute="leadingMargin" constant="40" id="Ntg-RE-5jW"/>
                             <constraint firstItem="7Xf-pd-kKj" firstAttribute="centerX" secondItem="KQU-J2-YtO" secondAttribute="centerX" id="ZLE-fH-J6V"/>
                             <constraint firstItem="7Xf-pd-kKj" firstAttribute="top" secondItem="5Be-hS-t4B" secondAttribute="bottom" constant="15" id="cUU-yE-4HQ"/>
+                            <constraint firstItem="Czh-eH-GW2" firstAttribute="centerX" secondItem="KQU-J2-YtO" secondAttribute="centerX" constant="113" id="eWC-8Z-mLR"/>
                             <constraint firstItem="Czh-eH-GW2" firstAttribute="centerY" secondItem="5Be-hS-t4B" secondAttribute="centerY" id="ig9-pr-Tul"/>
                         </constraints>
                     </view>
@@ -255,7 +254,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="b4o-MU-xOf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3672.8000000000002" y="-1076.311844077961"/>
+            <point key="canvasLocation" x="3672.4637681159425" y="-1076.9021739130435"/>
         </scene>
         <!--Issues View Controller-->
         <scene sceneID="URD-JJ-gfS">
@@ -506,7 +505,7 @@ The Department of the Army's Civil Works division will be accepting public comme
         <scene sceneID="VLC-fS-43C">
             <objects>
                 <navigationController id="IFq-NR-IrM" customClass="CustomNavigationController" customModule="FiveCalls" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="Kdw-tv-5oW">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="Kdw-tv-5oW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="1" green="0.00033646567799999999" blue="0.13182058469999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -524,7 +523,7 @@ The Department of the Army's Civil Works division will be accepting public comme
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="vbp-Kz-LRR" customClass="CustomNavigationController" customModule="FiveCalls" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="jhT-Oj-KcC">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="jhT-Oj-KcC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="1" green="0.00033646567799999999" blue="0.13182058469999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -959,7 +958,7 @@ I'm calling to express my deep opposition to the confirmation of Betsy DeVos for
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="uCI-we-dEY" customClass="CustomNavigationController" customModule="FiveCalls" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="3VD-Ro-n8g">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="3VD-Ro-n8g">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.09546948224" green="0.45810282229999999" blue="0.81936717029999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/FiveCalls/FiveCalls/Main.storyboard
+++ b/FiveCalls/FiveCalls/Main.storyboard
@@ -4,7 +4,6 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
@@ -170,9 +169,8 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Be-hS-t4B" customClass="BlueButton" customModule="FiveCalls" customModuleProvider="target">
-                                <rect key="frame" x="82" y="35" width="250" height="44"/>
+                                <rect key="frame" x="60" y="15" width="294" height="44"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="250" id="0nZ-07-gNh"/>
                                     <constraint firstAttribute="height" constant="44" id="HAO-vV-2NC"/>
                                 </constraints>
                                 <state key="normal" title="Use My Location"/>
@@ -185,18 +183,30 @@
                                     <action selector="useMyLocationTapped:" destination="mvc-KU-4ug" eventType="touchUpInside" id="w4g-PD-9WK"/>
                                 </connections>
                             </button>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Zip Code" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8JR-Y0-Fwm">
-                                <rect key="frame" x="79" y="170" width="256" height="59"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Or Enter Your Zip Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Xf-pd-kKj">
+                                <rect key="frame" x="118.66666666666669" y="74" width="177" height="21"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Czh-eH-GW2">
+                                <rect key="frame" x="298" y="27" width="20" height="20"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="59" id="MkO-so-yUl"/>
-                                    <constraint firstAttribute="width" constant="256" id="QrQ-A4-eTQ"/>
+                                    <constraint firstAttribute="width" constant="20" id="Cmb-88-OrV"/>
+                                    <constraint firstAttribute="height" constant="20" id="RyP-Pd-DBq"/>
+                                </constraints>
+                            </activityIndicatorView>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Zip Code" textAlignment="center" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="8JR-Y0-Fwm">
+                                <rect key="frame" x="44" y="110" width="220" height="55"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="55" id="MkO-so-yUl"/>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S0o-QZ-kcL" customClass="BlueButton" customModule="FiveCalls" customModuleProvider="target">
-                                <rect key="frame" x="235" y="237" width="100" height="40"/>
+                                <rect key="frame" x="270" y="117.66666666666666" width="100" height="39.999999999999972"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="KTK-f0-lqy"/>
                                     <constraint firstAttribute="width" constant="100" id="vDF-j1-Q3J"/>
@@ -211,28 +221,22 @@
                                     <action selector="submitZipCodeTapped:" destination="mvc-KU-4ug" eventType="touchUpInside" id="zWm-0b-uhZ"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Or Enter Your Zip Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Xf-pd-kKj">
-                                <rect key="frame" x="118.66666666666669" y="129" width="177" height="21"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Czh-eH-GW2">
-                                <rect key="frame" x="196.66666666666666" y="97" width="20" height="20"/>
-                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="8JR-Y0-Fwm" firstAttribute="top" secondItem="7Xf-pd-kKj" secondAttribute="bottom" constant="20" id="7A2-4j-2Kd"/>
+                            <constraint firstItem="S0o-QZ-kcL" firstAttribute="centerY" secondItem="8JR-Y0-Fwm" secondAttribute="centerY" id="2P6-YJ-o2d"/>
+                            <constraint firstItem="8JR-Y0-Fwm" firstAttribute="leading" secondItem="KQU-J2-YtO" secondAttribute="leadingMargin" constant="24" id="2hr-BI-3Au"/>
+                            <constraint firstItem="5Be-hS-t4B" firstAttribute="top" secondItem="Et2-qp-YNn" secondAttribute="bottom" constant="15" id="4T8-uL-Dh5"/>
+                            <constraint firstItem="8JR-Y0-Fwm" firstAttribute="top" secondItem="7Xf-pd-kKj" secondAttribute="bottom" constant="15" id="7A2-4j-2Kd"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="S0o-QZ-kcL" secondAttribute="trailing" constant="24" id="BD1-tr-VbL"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="5Be-hS-t4B" secondAttribute="trailing" constant="40" id="Bel-jv-IRK"/>
                             <constraint firstItem="5Be-hS-t4B" firstAttribute="centerX" secondItem="KQU-J2-YtO" secondAttribute="centerX" id="E3V-Vx-8rH"/>
-                            <constraint firstItem="8JR-Y0-Fwm" firstAttribute="centerX" secondItem="KQU-J2-YtO" secondAttribute="centerX" id="UPg-Vu-nhW"/>
+                            <constraint firstItem="S0o-QZ-kcL" firstAttribute="leading" secondItem="8JR-Y0-Fwm" secondAttribute="trailing" constant="6" id="Jvz-Vm-DCI"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="Czh-eH-GW2" secondAttribute="trailing" constant="76" id="M3Q-bK-g0j"/>
+                            <constraint firstItem="5Be-hS-t4B" firstAttribute="leading" secondItem="KQU-J2-YtO" secondAttribute="leadingMargin" constant="40" id="Ntg-RE-5jW"/>
                             <constraint firstItem="7Xf-pd-kKj" firstAttribute="centerX" secondItem="KQU-J2-YtO" secondAttribute="centerX" id="ZLE-fH-J6V"/>
-                            <constraint firstItem="5Be-hS-t4B" firstAttribute="top" secondItem="Et2-qp-YNn" secondAttribute="bottom" constant="35" id="ZNd-b0-REt"/>
-                            <constraint firstItem="7Xf-pd-kKj" firstAttribute="top" secondItem="5Be-hS-t4B" secondAttribute="bottom" constant="50" id="cUU-yE-4HQ"/>
-                            <constraint firstItem="Czh-eH-GW2" firstAttribute="centerX" secondItem="5Be-hS-t4B" secondAttribute="centerX" id="iNx-di-srp"/>
-                            <constraint firstItem="S0o-QZ-kcL" firstAttribute="trailing" secondItem="8JR-Y0-Fwm" secondAttribute="trailing" id="ryI-r3-ggg"/>
-                            <constraint firstItem="S0o-QZ-kcL" firstAttribute="top" secondItem="8JR-Y0-Fwm" secondAttribute="bottom" constant="8" id="tGR-Ac-u2c"/>
-                            <constraint firstItem="Czh-eH-GW2" firstAttribute="top" secondItem="5Be-hS-t4B" secondAttribute="bottom" constant="18" id="w6T-V6-cMv"/>
+                            <constraint firstItem="7Xf-pd-kKj" firstAttribute="top" secondItem="5Be-hS-t4B" secondAttribute="bottom" constant="15" id="cUU-yE-4HQ"/>
+                            <constraint firstItem="Czh-eH-GW2" firstAttribute="centerY" secondItem="5Be-hS-t4B" secondAttribute="centerY" id="ig9-pr-Tul"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Set Your Location" id="fjz-4h-IsH">

--- a/FiveCalls/FiveCalls/StatsPageViewController.swift
+++ b/FiveCalls/FiveCalls/StatsPageViewController.swift
@@ -16,6 +16,9 @@ protocol FinalPage {
 class StatsPageViewController : UIViewController, FinalPage {
     
     var didFinishBlock: ((Void) -> Void)?
+    @IBOutlet weak var topMargin: NSLayoutConstraint!
+    @IBOutlet weak var bottomMargin: NSLayoutConstraint!
+    @IBOutlet weak var buttonHeight: NSLayoutConstraint!
     
     @IBAction func getStartedTapped(_ sender: Any) {
         didFinishBlock?()
@@ -43,6 +46,13 @@ class StatsPageViewController : UIViewController, FinalPage {
         if viewModel == nil {
             label.alpha = 0
             loadStats()
+        }
+        
+        // If iPhone 4S
+        if UIScreen.main.bounds.size.height <= 480 {
+            topMargin.constant = 0
+            bottomMargin.constant = 0
+            buttonHeight.constant = 44
         }
     }
     


### PR DESCRIPTION
* Redesign the Edit Location page to fit on iPhone 4S
* Custom resizes Welcome Screen constraints when on an iPhone 4S
* Fixes fonts getting clipped on iPhone 5/SE Models on Welcome Screen
* Fixes custom fonts not showing on iOS 9

New Edit Location Screen Layout

![simulator screen shot feb 10 2017 11 19 38 pm](https://cloud.githubusercontent.com/assets/45654/22851441/6c127a42-efe7-11e6-9a3c-64c6d64dc06b.png)

Tweaked Layout of Welcome on iPhone 4S
![simulator screen shot feb 10 2017 11 19 19 pm](https://cloud.githubusercontent.com/assets/45654/22851444/7af838bc-efe7-11e6-8543-06a8ab63781b.png)

(Both of those running iOS 9 and the custom font working again)