### PR TITLE
Only reload tableview on viewDidAppear when data changes

### DIFF
--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -84,21 +84,25 @@ class CallScriptViewController : UIViewController, IssueShareable {
         default:
             print("unknown button pressed")
         }
+        
         if let outcomeName = button.titleLabel?.text {
             Answers.logCustomEvent(withName:"Action: Button \(outcomeName)", customAttributes: ["contact_id":contact.id])
         }
+        
         let contactedPhone = lastPhoneDialed.characters.count > 0 ? lastPhoneDialed : contact.phone
         let log = ContactLog(issueId: issue.id, contactId: contact.id, phone: contactedPhone, outcome: outcomeType, date: Date())
         reportCallOutcome(log)
         
-        var nextIndex = issueIndex+1
+        NotificationCenter.default.post(name: .callMade, object: log)
+        
+        var nextIndex = issueIndex + 1
         if issueIndex+1 >= issue.contacts.count {
             nextIndex = 0
         }
         if issue.contacts.indices.contains(nextIndex) {
             let nextContact = issue.contacts[nextIndex]
             showNextContact(nextContact)
-        }        
+        }
     }
     
     func showNextContact(_ contact: Contact) {

--- a/FiveCalls/FiveCalls/IssuesViewController.swift
+++ b/FiveCalls/FiveCalls/IssuesViewController.swift
@@ -11,6 +11,9 @@ import Crashlytics
 
 class IssuesViewController : UITableViewController {
     
+    // keep track of when calls are made, so we know if we need to reload any cells
+    var needToReloadVisibleRowsOnNextAppearance = false
+    
     var issuesManager = IssuesManager()
     var logs: ContactLogs?
     
@@ -25,6 +28,10 @@ class IssuesViewController : UITableViewController {
         tableView.rowHeight = UITableViewAutomaticDimension
         
         tableView.tableFooterView = UIView()
+        
+        NotificationCenter.default.addObserver(forName: .callMade, object: nil, queue: nil) { [weak self] _ in
+            self?.needToReloadVisibleRowsOnNextAppearance = true
+        }
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -38,7 +45,12 @@ class IssuesViewController : UITableViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        tableView.reloadRows(at: tableView.indexPathsForVisibleRows ?? [], with: .none)
+        
+        // only reload rows if we need to. this fixes a rare tableview inconsistency crash we've seen
+        if needToReloadVisibleRowsOnNextAppearance {
+            tableView.reloadRows(at: tableView.indexPathsForVisibleRows ?? [], with: .none)
+            needToReloadVisibleRowsOnNextAppearance = false
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/FiveCalls/FiveCalls/NotificationNames.swift
+++ b/FiveCalls/FiveCalls/NotificationNames.swift
@@ -10,4 +10,5 @@ import Foundation
 
 extension Notification.Name {
     static let locationChanged = Notification.Name("locationChanged")
+    static let callMade = Notification.Name("callMade")
 }


### PR DESCRIPTION
This was the cause of this crash:
http://crashes.to/s/1b10b5b1e3f

I assume that this `viewDidAppear` line was colliding with a normal
`reloadData` call on first load and that race condition resulted
in this crash.

I don't love this solution, I'm all ears for suggestions.