### PR TITLE
reduced lat/long accuracy to 3 signifigant digits to work around API bug #78

### DIFF
--- a/FiveCalls/FiveCalls/UserLocation.swift
+++ b/FiveCalls/FiveCalls/UserLocation.swift
@@ -59,7 +59,7 @@ class UserLocation {
     
     func setFrom(location: CLLocation, completion: @escaping (Void) -> Void) {
         locationType = .coordinates
-        locationValue = "\(location.coordinate.latitude),\(location.coordinate.longitude)"
+        locationValue = String(format: "%.3f,%.3f", location.coordinate.latitude, location.coordinate.longitude)
         locationDisplay = "..."
         getLocationInfo(from: location) { locationInfo in
             self.locationDisplay = locationInfo["displayName"] as? String


### PR DESCRIPTION
Looks like some weirdness in the Google Civic Information API. I think the significant digits gets us enough accuracy for anywhere in the country (from my VERY limited testing)