### PR TITLE
Reset unavailable after 12 hours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ fastlane/screenshots
 fastlane/test_output
 .env
 .ruby-version
+.DS_Store

--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -47,6 +47,14 @@ class CallScriptViewController : UIViewController, IssueShareable {
         
         tableView.estimatedRowHeight = 100
         tableView.rowHeight = UITableViewAutomaticDimension
+        NotificationCenter.default.addObserver(self, selector: #selector(removeOldAndUnavailableCalls), name: .UIApplicationDidBecomeActive, object: nil)
+    }
+    
+    func removeOldAndUnavailableCalls() {
+        if logs.hasOldAndUnavailableCalls {
+            logs = ContactLogs.load()
+            tableView.reloadData()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/FiveCalls/FiveCalls/ContactLog.swift
+++ b/FiveCalls/FiveCalls/ContactLog.swift
@@ -111,6 +111,13 @@ struct ContactLogs {
         }
     }
     
+    var hasOldAndUnavailableCalls: Bool {
+        for call in all {
+            if call.isOldAndUnavailable { return true }
+        }
+        return false
+    }
+    
     func save() {
         Pantry.pack(all, key: ContactLogs.persistenceKey)
     }

--- a/FiveCalls/FiveCalls/IssueDetailViewController.swift
+++ b/FiveCalls/FiveCalls/IssueDetailViewController.swift
@@ -36,6 +36,15 @@ class IssueDetailViewController : UIViewController, IssueShareable {
         
         tableView.estimatedRowHeight = 100
         tableView.rowHeight = UITableViewAutomaticDimension
+       
+        NotificationCenter.default.addObserver(self, selector: #selector(removeOldAndUnavailableCalls), name: .UIApplicationDidBecomeActive, object: nil)
+    }
+    
+    func removeOldAndUnavailableCalls() {
+        if logs?.hasOldAndUnavailableCalls == true {
+            logs = ContactLogs.load()
+            tableView.reloadData()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/FiveCalls/FiveCalls/IssuesViewController.swift
+++ b/FiveCalls/FiveCalls/IssuesViewController.swift
@@ -37,6 +37,15 @@ class IssuesViewController : UITableViewController {
         NotificationCenter.default.addObserver(forName: .callMade, object: nil, queue: nil) { [weak self] _ in
             self?.needToReloadVisibleRowsOnNextAppearance = true
         }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(removeOldAndUnavailableCalls), name: .UIApplicationDidBecomeActive, object: nil)
+    }
+    
+    func removeOldAndUnavailableCalls() {
+        if logs?.hasOldAndUnavailableCalls == true {
+            logs = ContactLogs.load()
+            tableView.reloadData()
+        }
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/FiveCalls/FiveCalls/UserLocation.swift
+++ b/FiveCalls/FiveCalls/UserLocation.swift
@@ -59,7 +59,7 @@ class UserLocation {
     
     func setFrom(location: CLLocation, completion: @escaping (Void) -> Void) {
         locationType = .coordinates
-        locationValue = "\(location.coordinate.latitude),\(location.coordinate.longitude)"
+        locationValue = String(format: "%.3f,%.3f", location.coordinate.latitude, location.coordinate.longitude)
         locationDisplay = "..."
         getLocationInfo(from: location) { locationInfo in
             self.locationDisplay = locationInfo["displayName"] as? String


### PR DESCRIPTION
- if a call is marked as "unavailable", and is older than 12 hours, then when it's read back into the log, it's skipped
- when re-entering the app, each screen that display a log will check to see if there are any old, unavailable calls in the log, and will remove them (by reloading the log) and then reloads the visible table.

Addresses #96 