### PR TITLE
Add alert when we can’t open the call URL

### DIFF
--- a/FiveCalls/FiveCalls/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppDelegate.swift
@@ -100,11 +100,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 extension UIApplication {
-    func fvc_open(_ url: URL) {
+    func fvc_open(_ url: URL, completion: ((Bool) -> Void)? = nil) {
         if #available(iOS 10.0, *) {
-            UIApplication.shared.open(url)
+            UIApplication.shared.open(url) {
+                completion?($0)
+            }
         } else {
-            UIApplication.shared.openURL(url)
+            let result = UIApplication.shared.openURL(url)
+            completion?(result)
         }
     }
 }

--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -94,9 +94,17 @@ class CallScriptViewController : UIViewController, IssueShareable {
         let defaults = UserDefaults.standard
         let firstCallInstructionsKey =  UserDefaultsKeys.hasSeenFirstCallInstructions.rawValue
         
+        let callErrorCompletion: (Bool) -> Void = { [weak self] successful in
+            if !successful {
+                DispatchQueue.main.async {
+                    self?.showCallFailedAlert()
+                }
+            }
+        }
+        
         if defaults.bool(forKey: firstCallInstructionsKey) {
             guard let dialURL = URL(string: "telprompt:\(number)") else { return }
-            UIApplication.shared.fvc_open(dialURL)
+            UIApplication.shared.fvc_open(dialURL, completion: callErrorCompletion)
         } else {
             let alertController = UIAlertController(title: R.string.localizable.firstCallAlertTitle(),
                                                     message:  R.string.localizable.firstCallAlertMessage(),
@@ -111,7 +119,7 @@ class CallScriptViewController : UIViewController, IssueShareable {
                                              style: .default) { _ in
                                                 alertController.dismiss(animated: true, completion: nil)
                                                 guard let dialURL = URL(string: "tel:\(number)") else { return }
-                                                UIApplication.shared.fvc_open(dialURL)
+                                                UIApplication.shared.fvc_open(dialURL, completion: callErrorCompletion)
                                                 
                                                 defaults.set(true, forKey: firstCallInstructionsKey)
             }
@@ -188,6 +196,21 @@ class CallScriptViewController : UIViewController, IssueShareable {
     
     func shareButtonPressed(_ button: UIBarButtonItem) {
         shareIssue(from: button)
+    }
+        
+    private func showCallFailedAlert() {
+        let alertController = UIAlertController(title: R.string.localizable.placeCallFailedTitle(),
+                                                message:  R.string.localizable.placeCallFailedMessage(),
+                                                preferredStyle: .alert)
+        
+        let okAction = UIAlertAction(title: R.string.localizable.okButtonTitle(),
+                                     style: .default) { _ in
+                                        alertController.dismiss(animated: true, completion: nil)
+        }
+        
+        alertController.addAction(okAction)
+        
+        present(alertController, animated: true, completion: nil)
     }
 }
 

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -36,3 +36,5 @@
 "first-call-alert-message"            = "We're about to place the call. When it starts dialing, turn on Speaker phone, then double tap the home button and return to this app so you can read the script.";
 "first-call-alert-cancel"             = "Cancel";
 "first-call-alert-call"               = "Call";
+"place-call-failed-title"             = "Unable to Call";
+"place-call-failed-message"           = "Sorry, it looks like we can't place a call on this device. If you prefer to, you can use your phone to call, and read the script from this screen.";


### PR DESCRIPTION
I was noodling around with the iPad version and noticed that we were failing silently when trying to place calls, so I added some semi-obvious advice in an alert to let people know they can't place calls from the device they're on. 