### PR TITLE
Add completion for address-based location updates

### DIFF
--- a/FiveCalls/FiveCalls/EditLocationViewController.swift
+++ b/FiveCalls/FiveCalls/EditLocationViewController.swift
@@ -66,9 +66,14 @@ class EditLocationViewController : UIViewController, CLLocationManagerDelegate {
     
     @IBAction func submitAddressTapped(_ sender: Any) {
             Answers.logCustomEvent(withName:"Action: Used Address")
-            let userLocation = UserLocation.current
-            userLocation.setFrom(address: addressTextField.text ?? "")
-            delegate?.editLocationViewController(self, didUpdateLocation: userLocation)
+        
+        UserLocation.current.setFrom(address: addressTextField.text ?? "") { [weak self] updatedLocation in
+            guard let strongSelf = self else {
+                return
+            }
+            
+            strongSelf.delegate?.editLocationViewController(strongSelf, didUpdateLocation: updatedLocation)
+        }
     }
 
     //Mark: CLLocationManagerDelegate methods

--- a/FiveCalls/FiveCalls/IssuesContainerViewController.swift
+++ b/FiveCalls/FiveCalls/IssuesContainerViewController.swift
@@ -156,11 +156,14 @@ class IssuesContainerViewController : UIViewController, EditLocationViewControll
     }
     
     func editLocationViewController(_ vc: EditLocationViewController, didUpdateLocation location: UserLocation) {
-        dismiss(animated: true) { [weak self] in
-            self?.issuesManager.userLocation = location
-            self?.issuesViewController.loadIssues()
-            self?.setTitleLabel(location: location)
+        DispatchQueue.main.async { [weak self] in
+            self?.dismiss(animated: true) {
+                self?.issuesManager.userLocation = location
+                self?.issuesViewController.loadIssues()
+                self?.setTitleLabel(location: location)
+            }
         }
+        
     }
     
     // MARK: - Private functions

--- a/FiveCalls/FiveCalls/UserLocation.swift
+++ b/FiveCalls/FiveCalls/UserLocation.swift
@@ -64,13 +64,14 @@ class UserLocation {
     
     private static let geocoder = CLGeocoder()
     
-    func setFrom(address: String) {
+    func setFrom(address: String, completion: ((UserLocation) -> Void)? = nil) {
         locationType = .address
         locationValue = address
         
         UserLocation.geocoder.geocodeAddressString(address) { results, error in
             defer {
                 self.locationChanged()
+                completion?(self)
             }
             
             guard let placemark = results?.first else {


### PR DESCRIPTION
Geocoding makes setting from address asynchronous, so we need to wait to invoke our UI updates until the geocode attempt has completed.