### PR TITLE
Move pantry files to app support

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -9,9 +9,9 @@
 /* Begin PBXBuildFile section */
 		061B964448DA5CCCC94994E2 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B7C84D8023A9154688796F /* CoreText.framework */; };
 		0F76D3801E4FE05B00C14543 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F76D37F1E4FE05B00C14543 /* R.generated.swift */; };
+		1F79FDA51E668A7F00AE4CDC /* IssueScriptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F79FDA41E668A7F00AE4CDC /* IssueScriptCell.swift */; };
 		271625411E52502D0042222E /* ScheduleRemindersController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271625401E52502D0042222E /* ScheduleRemindersController.swift */; };
 		271625431E5250BA0042222E /* MultipleSelectionSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271625421E5250BA0042222E /* MultipleSelectionSegmentedControl.swift */; };
-		1F79FDA51E668A7F00AE4CDC /* IssueScriptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F79FDA41E668A7F00AE4CDC /* IssueScriptCell.swift */; };
 		2732D7C71E4300F300F149EF /* NotificationNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2732D7C61E4300F300F149EF /* NotificationNames.swift */; };
 		33C2E0E61E52A95900F810C6 /* UIView+FiveCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C2E0E51E52A95900F810C6 /* UIView+FiveCalls.swift */; };
 		33C2E0E81E52ADC200F810C6 /* UIColor+FiveCalls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C2E0E71E52ADC200F810C6 /* UIColor+FiveCalls.swift */; };
@@ -113,9 +113,9 @@
 		0C879891BE224AEC07E153B3 /* Pods-FiveCalls.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FiveCalls.release.xcconfig"; path = "Pods/Target Support Files/Pods-FiveCalls/Pods-FiveCalls.release.xcconfig"; sourceTree = "<group>"; };
 		0F76D37F1E4FE05B00C14543 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = SOURCE_ROOT; };
 		1B215EF9496565D48AC664AD /* Pods-FiveCalls.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FiveCalls.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FiveCalls/Pods-FiveCalls.debug.xcconfig"; sourceTree = "<group>"; };
+		1F79FDA41E668A7F00AE4CDC /* IssueScriptCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueScriptCell.swift; sourceTree = "<group>"; };
 		271625401E52502D0042222E /* ScheduleRemindersController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduleRemindersController.swift; sourceTree = "<group>"; };
 		271625421E5250BA0042222E /* MultipleSelectionSegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleSelectionSegmentedControl.swift; sourceTree = "<group>"; };
-		1F79FDA41E668A7F00AE4CDC /* IssueScriptCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssueScriptCell.swift; sourceTree = "<group>"; };
 		2732D7C61E4300F300F149EF /* NotificationNames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationNames.swift; sourceTree = "<group>"; };
 		276D3D9C9BE74743772C8E99 /* Pods-FiveCallsTests-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "Pods-FiveCallsTests-metadata.plist"; path = "Pods/Pods-FiveCallsTests-metadata.plist"; sourceTree = "<group>"; };
 		3202C128B897181FF4B6D7D8 /* Pods_FiveCallsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FiveCallsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/FiveCalls/Podfile
+++ b/FiveCalls/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 plugin 'cocoapods-acknowledgements'
 
 def common_pods
-  pod 'Pantry'
+  pod 'Pantry', git: 'https://github.com/nickoneill/pantry.git', branch: 'nick-file-protection' # needed for app support folder change
   pod 'R.swift'
 end
 

--- a/FiveCalls/Podfile.lock
+++ b/FiveCalls/Podfile.lock
@@ -16,17 +16,23 @@ DEPENDENCIES:
   - DropDown
   - DZNEmptyDataSet (from `https://github.com/subdigital/DZNEmptyDataSet`)
   - Fabric
-  - Pantry
+  - Pantry (from `https://github.com/nickoneill/pantry.git`, branch `nick-file-protection`)
   - R.swift
 
 EXTERNAL SOURCES:
   DZNEmptyDataSet:
     :git: https://github.com/subdigital/DZNEmptyDataSet
+  Pantry:
+    :branch: nick-file-protection
+    :git: https://github.com/nickoneill/pantry.git
 
 CHECKOUT OPTIONS:
   DZNEmptyDataSet:
     :commit: ee32a46e6e79f9c84b2e3caf75f52b4948b01406
     :git: https://github.com/subdigital/DZNEmptyDataSet
+  Pantry:
+    :commit: 2d666b78df5c2782f28c0f2b62b941c7c15946d2
+    :git: https://github.com/nickoneill/pantry.git
 
 SPEC CHECKSUMS:
   CPDAcknowledgements: 6e15e71849ba4ad5e8a17a0bb9d20938ad23bac8
@@ -38,6 +44,6 @@ SPEC CHECKSUMS:
   R.swift: 207a372a2b5977caef440c696a368009460641d1
   R.swift.Library: fbdec16c9802ad104fc1ba53415dc190e6ec5c73
 
-PODFILE CHECKSUM: a01f3e98da0ebd079cf9e2a87c086b918e5b5f86
+PODFILE CHECKSUM: 62654a3403745858f7d5d1e21f1e39df459ce6f1
 
 COCOAPODS: 1.2.0

--- a/FiveCalls/Pods/Local Podspecs/Pantry.podspec.json
+++ b/FiveCalls/Pods/Local Podspecs/Pantry.podspec.json
@@ -1,0 +1,20 @@
+{
+  "name": "Pantry",
+  "version": "0.3",
+  "license": "MIT",
+  "summary": "The missing light persistence layer for Swift",
+  "homepage": "https://github.com/nickoneill/Pantry",
+  "social_media_url": "https://twitter.com/objctoswift",
+  "authors": {
+    "Nick O'Neill": "nick.oneill@gmail.com"
+  },
+  "source": {
+    "git": "https://github.com/nickoneill/Pantry.git",
+    "tag": "0.3"
+  },
+  "platforms": {
+    "ios": "8.0"
+  },
+  "source_files": "Pantry/*.swift",
+  "requires_arc": true
+}

--- a/FiveCalls/Pods/Manifest.lock
+++ b/FiveCalls/Pods/Manifest.lock
@@ -16,17 +16,23 @@ DEPENDENCIES:
   - DropDown
   - DZNEmptyDataSet (from `https://github.com/subdigital/DZNEmptyDataSet`)
   - Fabric
-  - Pantry
+  - Pantry (from `https://github.com/nickoneill/pantry.git`, branch `nick-file-protection`)
   - R.swift
 
 EXTERNAL SOURCES:
   DZNEmptyDataSet:
     :git: https://github.com/subdigital/DZNEmptyDataSet
+  Pantry:
+    :branch: nick-file-protection
+    :git: https://github.com/nickoneill/pantry.git
 
 CHECKOUT OPTIONS:
   DZNEmptyDataSet:
     :commit: ee32a46e6e79f9c84b2e3caf75f52b4948b01406
     :git: https://github.com/subdigital/DZNEmptyDataSet
+  Pantry:
+    :commit: 2d666b78df5c2782f28c0f2b62b941c7c15946d2
+    :git: https://github.com/nickoneill/pantry.git
 
 SPEC CHECKSUMS:
   CPDAcknowledgements: 6e15e71849ba4ad5e8a17a0bb9d20938ad23bac8
@@ -38,6 +44,6 @@ SPEC CHECKSUMS:
   R.swift: 207a372a2b5977caef440c696a368009460641d1
   R.swift.Library: fbdec16c9802ad104fc1ba53415dc190e6ec5c73
 
-PODFILE CHECKSUM: a01f3e98da0ebd079cf9e2a87c086b918e5b5f86
+PODFILE CHECKSUM: 62654a3403745858f7d5d1e21f1e39df459ce6f1
 
 COCOAPODS: 1.2.0

--- a/FiveCalls/Pods/Pantry/Pantry/JSONWarehouse.swift
+++ b/FiveCalls/Pods/Pantry/Pantry/JSONWarehouse.swift
@@ -114,9 +114,15 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
         storableDictionary["expires"] = expires.toDate().timeIntervalSince1970
         storableDictionary["storage"] = object
 
+        guard JSONSerialization.isValidJSONObject(storableDictionary) else {
+            debugPrint("Not a valid JSON object: \(object)")
+            return
+        }
+
         do {
             let data = try JSONSerialization.data(withJSONObject: storableDictionary, options: .prettyPrinted)
-            try data.write(to: cacheLocation, options: .atomic)
+
+            try data.write(to: cacheLocation, options: [.atomic, .completeFileProtectionUnlessOpen])
         } catch {
             debugPrint("\(error)")
         }
@@ -183,8 +189,13 @@ open class JSONWarehouse: Warehouseable, WarehouseCacheable {
     }
     
     static var cacheDirectory: URL {
-        let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
-        
+        let url: URL
+        if Pantry.useApplicationSupportDirectory {
+            url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        } else {
+            url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        }
+
         let writeDirectory = url.appendingPathComponent("com.thatthinginswift.pantry")
         return writeDirectory
     }

--- a/FiveCalls/Pods/Pantry/Pantry/Mirror+Serialization.swift
+++ b/FiveCalls/Pods/Pantry/Pantry/Mirror+Serialization.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Mirror {
     /**
      Dictionary representation
-     Returns the dictioanry representation of the current `Mirror`
+     Returns the dictionary representation of the current `Mirror`
      
      _Adapted from [@IanKeen](https://gist.github.com/IanKeen/3a6c3b9a42aaf9fea982)_
      - returns: [String: Any]

--- a/FiveCalls/Pods/Pantry/Pantry/Pantry.swift
+++ b/FiveCalls/Pods/Pantry/Pantry/Pantry.swift
@@ -35,6 +35,9 @@ open class Pantry {
     // Set to a string identifier to enable in memory mode with no persistent caching. Useful for unit testing.
     open static var enableInMemoryModeWithIdentifier: String?
 
+    // This is where we should actually store things, flag for now so people can upgrade
+    open static var useApplicationSupportDirectory: Bool = false
+
     // MARK: pack generics
 
     /**

--- a/FiveCalls/Pods/Pantry/Pantry/Storable.swift
+++ b/FiveCalls/Pods/Pantry/Pantry/Storable.swift
@@ -39,7 +39,7 @@ public protocol Storable {
     /**
      Dictionary representation  
 
-     Returns the dictioanry representation of the current struct
+     Returns the dictionary representation of the current struct
      - returns: [String: Any]
      */
     func toDictionary() -> [String: Any]
@@ -48,7 +48,7 @@ public protocol Storable {
 public extension Storable {
     /**
      Dictionary representation
-     Returns the dictioanry representation of the current struct
+     Returns the dictionary representation of the current struct
      
      - returns: [String: Any]
      */

--- a/FiveCalls/Pods/Pantry/README.md
+++ b/FiveCalls/Pods/Pantry/README.md
@@ -119,7 +119,7 @@ struct Basic: Storable {
         self.number = warehouse.get("number") ?? 10
     }
 
-    func toDictionary() -> [String : AnyObject] {
+    func toDictionary() -> [String : Any] {
         return [ "name": self.name, "age": self.age, "number": self.number ]
     }
 }
@@ -133,12 +133,12 @@ Classes are also supported and can be setup the same way Structs are however the
 ```swift
 class ModelBase: Storable {
     let id: String
-    
+
     required init(warehouse: Warehouseable) {
         self.id = warehouse.get("id") ?? "default_id"
     }
 
-    func toDictionary() -> [String : AnyObject] {
+    func toDictionary() -> [String : Any] {
         return [ "id": self.id ]
     }
 }
@@ -147,16 +147,16 @@ class BasicClassModel: ModelBase {
     let name: String
     let age: Float
     let number: Int
-    
+
     required init(warehouse: Warehouseable) {
         self.name = warehouse.get("name") ?? "default"
         self.age = warehouse.get("age") ?? 20.5
         self.number = warehouse.get("number") ?? 10
-        
+
         super.init(warehouse: warehouse)
     }
 
-    func toDictionary() -> [String : AnyObject] {
+    func toDictionary() -> [String : Any] {
         var dictionary = super.toDictionary()
         dictionary["name"] = self.name
         dictionary["age"] = self.age


### PR DESCRIPTION
This checks on app startup for existence of the pantry cache folder, migrating it to Application Support if necessary. If the target folder exists already or some other error happens, we log it and continue.

The user will lose data if this ever happens, but it would be pretty rare and not entirely critical.

(Worth noting that users with low disk space are already losing data :/)