### PR TITLE
Adding 3D Touch support going from Issue to IssueDetail

### DIFF
--- a/FiveCalls/FiveCalls/AboutHtmlViewController.swift
+++ b/FiveCalls/FiveCalls/AboutHtmlViewController.swift
@@ -22,7 +22,6 @@ class AboutHtmlViewController : UIViewController, UIWebViewDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationController?.navigationBar.tintColor = .white
         Answers.logCustomEvent(withName: "Screen: About \(contentName)")
         let path = Bundle.main.path(forResource: "about-\(contentName)", ofType: "html")!
         let data = try! Data(contentsOf: URL(fileURLWithPath: path))

--- a/FiveCalls/FiveCalls/AboutViewController.swift
+++ b/FiveCalls/FiveCalls/AboutViewController.swift
@@ -31,7 +31,6 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationController?.navigationBar.tintColor = .white
         Answers.logCustomEvent(withName:"Screen: About")
     }
 

--- a/FiveCalls/FiveCalls/Appearance.swift
+++ b/FiveCalls/FiveCalls/Appearance.swift
@@ -36,6 +36,8 @@ class Appearance {
         UINavigationBar.appearance().titleTextAttributes =
             [NSFontAttributeName: headerFont,
              NSForegroundColorAttributeName : UIColor.white]
+        
+        UINavigationBar.appearance().tintColor = UIColor.white
     }
     
     private func appFont(size: CGFloat, bold: Bool) -> UIFont! {

--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -42,7 +42,6 @@ class CallScriptViewController : UIViewController, IssueShareable {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationController?.navigationBar.tintColor = .white
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(IssueDetailViewController.shareButtonPressed(_ :)))
         
         tableView.estimatedRowHeight = 100

--- a/FiveCalls/FiveCalls/IssueDetailViewController.swift
+++ b/FiveCalls/FiveCalls/IssueDetailViewController.swift
@@ -24,9 +24,7 @@ class IssueDetailViewController : UIViewController, IssueShareable {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        navigationController?.navigationBar.tintColor = .white
-        
+                
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(IssueDetailViewController.shareButtonPressed(_ :)))
         
         tableView.estimatedRowHeight = 100

--- a/FiveCalls/FiveCalls/IssuesViewController.swift
+++ b/FiveCalls/FiveCalls/IssuesViewController.swift
@@ -38,7 +38,8 @@ class IssuesViewController : UITableViewController {
 
         tableView.emptyDataSetDelegate = self
         tableView.emptyDataSetSource = self
-        
+        self.registerForPreviewing(with: self, sourceView: tableView)
+
         Answers.logCustomEvent(withName:"Screen: Issues List")
         
         navigationController?.setNavigationBarHidden(true, animated: false)
@@ -171,6 +172,27 @@ class IssuesViewController : UITableViewController {
         }
         return cell
     }
+
+}
+
+extension IssuesViewController: UIViewControllerPreviewingDelegate {
+    
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
+        guard let indexPath = tableView.indexPathForRow(at: location) else { return nil }
+        guard let detailViewController = R.storyboard.main.issueDetailViewController() else { return nil }
+        guard let cell = tableView.cellForRow(at: indexPath) else { return nil }
+        
+        detailViewController.issuesManager = issuesManager
+        detailViewController.issue = issuesManager.issues[indexPath.row]
+        previewingContext.sourceRect = cell.frame
+        
+        return detailViewController
+    }
+    
+    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
+        self.show(viewControllerToCommit, sender: self)
+    }
+    
 }
 
 extension IssuesViewController : DZNEmptyDataSetSource {


### PR DESCRIPTION
This PR adds 3D Touch support, which looks like this.

![3d touch](https://cloud.githubusercontent.com/assets/716513/23827479/5c9dcbaa-0682-11e7-8ce0-4b8ffaf50588.PNG)

I also moved to using UIAppearance for setting the navigation bar tint color for 2 reasons.
1) There's less logic to maintain.
2) It removes the implicit state of a `UINavigationController` existing at the time of `viewDidLoad`, which is not true when presenting via a `UIViewControllerPreviewing`.

Lemme know if there's anything I need to tweak or change.

Thanks!