### PR TITLE
Force the user to choose a day if the reminders are enabled

### DIFF
--- a/FiveCalls/FiveCalls/Base.lproj/About.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/About.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZRq-uX-bkA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZRq-uX-bkA">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -211,7 +211,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yah-e7-5L0" customClass="MultipleSelectionControl" customModule="FiveCalls" customModuleProvider="target">
-                                <rect key="frame" x="16" y="597" width="343" height="50"/>
+                                <rect key="frame" x="16" y="589" width="343" height="50"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="hQX-ZO-baD"/>
@@ -248,9 +248,15 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Which days of the week?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uvj-Tf-rza">
-                                <rect key="frame" x="75" y="565" width="225" height="24"/>
+                                <rect key="frame" x="75" y="557" width="225" height="24"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <color key="textColor" red="0.09546948224" green="0.45810282229999999" blue="0.81936717029999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No days selected yet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mD9-Ki-KK0">
+                                <rect key="frame" x="128.5" y="643" width="118.5" height="14"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" red="0.81568627449999997" green="0.0078431372550000003" blue="0.1058823529" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -260,17 +266,20 @@
                             <constraint firstItem="yah-e7-5L0" firstAttribute="leading" secondItem="l2f-16-hXo" secondAttribute="leading" constant="16" id="9P8-N0-bvk"/>
                             <constraint firstAttribute="trailing" secondItem="LX5-gE-C8x" secondAttribute="trailing" constant="20" id="9p9-8D-3S2"/>
                             <constraint firstAttribute="trailing" secondItem="yah-e7-5L0" secondAttribute="trailing" constant="16" id="Mf0-h2-4hl"/>
+                            <constraint firstItem="mD9-Ki-KK0" firstAttribute="centerX" secondItem="yah-e7-5L0" secondAttribute="centerX" id="NDC-aU-1re"/>
                             <constraint firstItem="LX5-gE-C8x" firstAttribute="leading" secondItem="l2f-16-hXo" secondAttribute="leading" constant="20" id="Pou-e0-oiM"/>
+                            <constraint firstItem="mD9-Ki-KK0" firstAttribute="top" secondItem="yah-e7-5L0" secondAttribute="bottom" constant="4" id="SJ0-YE-Aos"/>
                             <constraint firstItem="uvj-Tf-rza" firstAttribute="centerX" secondItem="l2f-16-hXo" secondAttribute="centerX" id="WWr-p8-eFF"/>
                             <constraint firstItem="yah-e7-5L0" firstAttribute="top" secondItem="uvj-Tf-rza" secondAttribute="bottom" constant="8" id="Ys3-hR-weo"/>
                             <constraint firstAttribute="trailing" secondItem="pgL-vc-xhW" secondAttribute="trailing" id="qEu-2S-EMB"/>
-                            <constraint firstItem="VJl-BZ-EkK" firstAttribute="top" secondItem="yah-e7-5L0" secondAttribute="bottom" constant="20" id="sb2-ri-4nF"/>
+                            <constraint firstItem="VJl-BZ-EkK" firstAttribute="top" secondItem="yah-e7-5L0" secondAttribute="bottom" constant="28" id="sb2-ri-4nF"/>
                             <constraint firstItem="pgL-vc-xhW" firstAttribute="leading" secondItem="l2f-16-hXo" secondAttribute="leading" id="waQ-0f-lpw"/>
                             <constraint firstItem="LX5-gE-C8x" firstAttribute="top" secondItem="aqG-iY-BBR" secondAttribute="bottom" constant="20" id="yYb-oB-wSx"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="daysOfWeekSelector" destination="yah-e7-5L0" id="fnO-nX-bCk"/>
+                        <outlet property="noDaysWarningLabel" destination="mD9-Ki-KK0" id="TYp-c6-tCW"/>
                         <outlet property="timePicker" destination="pgL-vc-xhW" id="rQ7-sg-jua"/>
                     </connections>
                 </viewController>
@@ -318,7 +327,7 @@
             <objects>
                 <navigationController storyboardIdentifier="aboutNavController" automaticallyAdjustsScrollViewInsets="NO" modalPresentationStyle="pageSheet" id="ZRq-uX-bkA" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" translucent="NO" id="r70-ye-hKT">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" barStyle="black" translucent="NO" id="r70-ye-hKT">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.09546948224" green="0.45810282229999999" blue="0.81936717029999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/FiveCalls/FiveCalls/ScheduleRemindersController.swift
+++ b/FiveCalls/FiveCalls/ScheduleRemindersController.swift
@@ -12,6 +12,7 @@ class ScheduleRemindersController: UIViewController {
 
     @IBOutlet weak var timePicker: UIDatePicker!
     @IBOutlet weak var daysOfWeekSelector: MultipleSelectionControl!
+    @IBOutlet weak var noDaysWarningLabel: UILabel!
 
     lazy private var overlay: UIView = {
         let overlay = UIView()
@@ -98,7 +99,6 @@ class ScheduleRemindersController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         if let notifications = UIApplication.shared.scheduledLocalNotifications {
             daysOfWeekSelector.setSelectedButtons(at: indices(from: notifications))
             if let date = notifications.first?.fireDate {
@@ -118,6 +118,10 @@ class ScheduleRemindersController: UIViewController {
         timePicker.setValue(UIColor.fvc_darkBlue, forKey: "textColor")
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateDaysWarning()
+    }
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         guard notificationsChanged == true && remindersEnabled else { return }
@@ -130,7 +134,12 @@ class ScheduleRemindersController: UIViewController {
     }
 
     @objc private func dismissAction(_ sender: UIBarButtonItem) {
-        dismiss(animated: true, completion: nil)
+        let cannotDismiss = noDaysSelected() && remindersEnabled
+        if cannotDismiss {
+            shakeDays()
+        } else {
+            dismiss(animated: true, completion: nil)
+        }
     }
     
     private func clearNotifications() {
@@ -143,6 +152,32 @@ class ScheduleRemindersController: UIViewController {
 
     @IBAction func dayPickerAction(_ sender: MultipleSelectionControl) {
         notificationsChanged = true
+        updateDaysWarning()
+    }
+
+    func updateDaysWarning() {
+        if daysOfWeekSelector.selectedIndices.count == 0 {
+            self.daysOfWeekSelector.layer.borderColor = UIColor.red.cgColor
+            self.daysOfWeekSelector.layer.borderWidth = 1.0
+            self.noDaysWarningLabel.isHidden = false
+        } else {
+            self.daysOfWeekSelector.layer.borderWidth = 0.0
+            self.noDaysWarningLabel.isHidden = true
+        }
+    }
+
+    private func noDaysSelected() -> Bool {
+        return daysOfWeekSelector.selectedIndices.count == 0
+    }
+
+    private func shakeDays() {
+        UIView.animate(withDuration: 0.14, animations: {
+            self.daysOfWeekSelector.transform = CGAffineTransform(translationX: 10, y: 0)
+        }) { (complete) in
+            UIView.animate(withDuration: 0.22, delay: 0, usingSpringWithDamping: 0.23, initialSpringVelocity: 1.0, options: .curveLinear, animations: {
+                self.daysOfWeekSelector.transform = CGAffineTransform(translationX: 0, y: 0)
+            }, completion: nil)
+        }
     }
 
     private func indices(from notifications: [UILocalNotification]) -> [Int] {


### PR DESCRIPTION
I noticed that I had enabled notifications but failed to notice that I did not have any selected days, so I wasn't getting  reminder. 

The existing UI failed to make entirely clear to a new user that light blue means that they are not selected.

I added a red border and small text to indicate that no days are selected.
A user cannot dismiss the controller without either selecting a day, or disabling the reminders