### PR TITLE
Tappable Footer for Rep. Contacts

### DIFF
--- a/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
@@ -348,7 +348,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="wwf-aP-AUR">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="wwf-aP-AUR">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>

--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -271,6 +271,3 @@ extension CallScriptViewController : UITableViewDataSource {
     }
 }
 
-extension IssueDetailViewController : UITableViewDelegate {
-
-}

--- a/FiveCalls/FiveCalls/Extensions/UIColor+FiveCalls.swift
+++ b/FiveCalls/FiveCalls/Extensions/UIColor+FiveCalls.swift
@@ -39,7 +39,8 @@ extension UIColor {
     static let fvc_superLightGray = UIColor(white: 0.96, alpha: 1.0)
     
     static let fvc_lightGray = UIColor(white: 0.90, alpha: 1.0)
-    
+    static let fvc_lightGrayBackground = UIColor(white: 245.0/255.0, alpha: 1.0)
+
     static let fvc_mediumGray = UIColor(white:0.88, alpha: 1.0)
     
     static let fvc_darkGray = UIColor(white: 0.4, alpha: 1.0)

--- a/FiveCalls/FiveCalls/IssueDetailViewController.swift
+++ b/FiveCalls/FiveCalls/IssueDetailViewController.swift
@@ -31,6 +31,26 @@ class IssueDetailViewController : UIViewController, IssueShareable {
         tableView.rowHeight = UITableViewAutomaticDimension
         NotificationCenter.default.addObserver(self, selector: #selector(madeCall), name: .callMade, object: nil)
     }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard section == IssueSections.header.rawValue else {
+            return nil
+        }
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 40.0))
+        let label = UILabel(frame: CGRect(x: 16, y: 0, width: tableView.frame.width - 32.0, height: 40))
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 40))
+        view.addSubview(label)
+        view.addSubview(button)
+
+        view.backgroundColor = .fvc_lightGrayBackground
+        label.text = R.string.localizable.callYourReps()
+        button.addTarget(self, action: #selector(footerAction(_:)), for: .touchUpInside)
+        return view
+    }
+
+    @objc func footerAction(_ sender: UIButton) {
+        self.tableView.scrollToRow(at: IndexPath(item: 0, section: 1), at: .top, animated: true)
+    }
     
     func madeCall() {
         logs = ContactLogs.load()
@@ -145,13 +165,6 @@ extension IssueDetailViewController : UITableViewDataSource {
                 return cell
             }
         }
-    }
-    
-    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        if !issue.contacts.isEmpty && section == IssueSections.contacts.rawValue {
-            return R.string.localizable.callYourReps()
-        }
-        return nil
     }
     
     private func headerCell(at indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
Added a persistent Section Footer to the first section so that a user can scroll to contacting representative. To improve discoverability for new users.

***Note***: This is proof-of-concept & implementation combined. No problem if it doesn't get merged for design/usability reasons.

I posted a video in slack #ios channel
