### PR TITLE
Disable Submit button when location is empty

### DIFF
--- a/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
@@ -231,8 +231,11 @@
                                         <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                                        <connections>
+                                            <action selector="addressTextFieldChanged" destination="mvc-KU-4ug" eventType="editingChanged" id="UYY-fv-VsB"/>
+                                        </connections>
                                     </textField>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S0o-QZ-kcL" customClass="BlueButton" customModule="FiveCalls" customModuleProvider="target">
+                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S0o-QZ-kcL" customClass="BlueButton" customModule="FiveCalls" customModuleProvider="target">
                                         <rect key="frame" x="94" y="89.5" width="100" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="KTK-f0-lqy"/>
@@ -275,6 +278,7 @@
                     <connections>
                         <outlet property="activityIndicator" destination="Czh-eH-GW2" id="MxA-Wv-if7"/>
                         <outlet property="addressTextField" destination="8JR-Y0-Fwm" id="ZBK-ZW-7FM"/>
+                        <outlet property="submitButton" destination="S0o-QZ-kcL" id="pfU-m4-76O"/>
                         <outlet property="useMyLocationButton" destination="5Be-hS-t4B" id="gVx-vZ-p5q"/>
                     </connections>
                 </viewController>

--- a/FiveCalls/FiveCalls/BlueButton.swift
+++ b/FiveCalls/FiveCalls/BlueButton.swift
@@ -47,14 +47,12 @@ class BlueButton: UIButton {
 
     override var isHighlighted: Bool {
         didSet {
-            titleLabel?.alpha = 1.0
             updateColors()
         }
     }
     
     override var isSelected: Bool {
         didSet {
-            titleLabel?.alpha = 1.0
             updateColors()
         }
     }
@@ -70,17 +68,11 @@ class BlueButton: UIButton {
         else if isSelected { backgroundColor = selectedBackgroundColor }
         else { backgroundColor = normalBackgroundColor }
         
-        if isEnabled {
-            alpha = 1.0
-            titleLabel?.alpha = 1.0
-        }
-        else {
-            alpha = 0.4
-            titleLabel?.alpha = 0.4
-        }
-
         setTitleColor(.white, for: .selected)
         setTitleColor(.white, for: .highlighted)
         setTitleColor(defaultTextColor, for: .normal)
+        
+        titleLabel?.alpha = 1.0
+        alpha = isEnabled ? 1.0 : 0.5
     }
 }

--- a/FiveCalls/FiveCalls/BlueButton.swift
+++ b/FiveCalls/FiveCalls/BlueButton.swift
@@ -59,10 +59,25 @@ class BlueButton: UIButton {
         }
     }
 
+    override var isEnabled: Bool {
+        didSet {
+            updateColors()
+        }
+    }
+    
     func updateColors() {
         if isHighlighted { backgroundColor = highlightBackgroundColor }
         else if isSelected { backgroundColor = selectedBackgroundColor }
         else { backgroundColor = normalBackgroundColor }
+        
+        if isEnabled {
+            alpha = 1.0
+            titleLabel?.alpha = 1.0
+        }
+        else {
+            alpha = 0.4
+            titleLabel?.alpha = 0.4
+        }
 
         setTitleColor(.white, for: .selected)
         setTitleColor(.white, for: .highlighted)

--- a/FiveCalls/FiveCalls/EditLocationViewController.swift
+++ b/FiveCalls/FiveCalls/EditLocationViewController.swift
@@ -20,6 +20,7 @@ class EditLocationViewController : UIViewController, CLLocationManagerDelegate {
     private var lookupLocation: CLLocation?
     @IBOutlet weak var addressLabel: UILabel!
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
+    @IBOutlet weak var submitButton: BlueButton!
 
     private lazy var locationManager: CLLocationManager = {
         let manager = CLLocationManager()
@@ -37,6 +38,7 @@ class EditLocationViewController : UIViewController, CLLocationManagerDelegate {
         
         if case .address? = UserLocation.current.locationType {
             addressTextField.text = UserLocation.current.locationValue
+            submitButton.isEnabled = true
         }
     }
     
@@ -70,8 +72,14 @@ class EditLocationViewController : UIViewController, CLLocationManagerDelegate {
             strongSelf.delegate?.editLocationViewController(strongSelf, didUpdateLocation: updatedLocation)
         }
     }
+    
+    @IBAction func addressTextFieldChanged() {
+        if let addressLength = addressTextField.text?.characters.count {
+            submitButton.isEnabled = addressLength > 0
+        }
+    }
 
-    //Mark: CLLocationManagerDelegate methods
+    //MARK: - CLLocationManagerDelegate methods
     
     func informUserOfPermissions() {
         let alertController = UIAlertController(title: R.string.localizable.locationPermissionDeniedTitle(), message:

--- a/FiveCalls/FiveCalls/EditLocationViewController.swift
+++ b/FiveCalls/FiveCalls/EditLocationViewController.swift
@@ -38,7 +38,7 @@ class EditLocationViewController : UIViewController, CLLocationManagerDelegate {
         
         if case .address? = UserLocation.current.locationType {
             addressTextField.text = UserLocation.current.locationValue
-            submitButton.isEnabled = true
+            addressTextFieldChanged()
         }
     }
     
@@ -74,7 +74,8 @@ class EditLocationViewController : UIViewController, CLLocationManagerDelegate {
     }
     
     @IBAction func addressTextFieldChanged() {
-        if let addressLength = addressTextField.text?.characters.count {
+        if let address = addressTextField.text?.trimmingCharacters(in: .whitespaces)  {
+            let addressLength = address.characters.count
             submitButton.isEnabled = addressLength > 0
         }
     }


### PR DESCRIPTION
With this change, the Submit button in the edit location view is enabled only
when there is text in the location textfield.

This addresses issue #143 in the 5calls/ios issue list.
