### PR TITLE
Re: Issue #141 - Update Button Styles

### DIFF
--- a/FiveCalls/FiveCalls/BlueButton.swift
+++ b/FiveCalls/FiveCalls/BlueButton.swift
@@ -39,7 +39,7 @@ class BlueButton: UIButton {
     
     private func _commonInit() {
         updateColors()
-        setTitle(titleLabel?.text?.uppercased(), for: .normal)
+        setTitle(titleLabel?.text?.capitalized, for: .normal)
         titleLabel?.font = R.font.robotoCondensedBold(size: customFontSize)
         layer.cornerRadius = 5
         clipsToBounds = true

--- a/FiveCalls/FiveCalls/BlueButton.swift
+++ b/FiveCalls/FiveCalls/BlueButton.swift
@@ -19,9 +19,9 @@ class BlueButton: UIButton {
     }
     
     var normalBackgroundColor: UIColor = .fvc_lightBlueBackground
-    var highlightBackgroundColor: UIColor = .fvc_red
-    var selectedBackgroundColor: UIColor = .fvc_red
-    var defaultTextColor: UIColor = .fvc_darkBlueText
+    var highlightBackgroundColor: UIColor = .fvc_darkBlue
+    var selectedBackgroundColor: UIColor = .fvc_darkBlue
+    var defaultTextColor: UIColor = .white
         
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -157,6 +157,10 @@ class CallScriptViewController : UIViewController, IssueShareable {
     }
     
     @IBAction func resultButtonPressed(_ button: UIButton) {
+        if let blueButton = button as? BlueButton {
+            blueButton.isSelected = true
+        }
+
         Answers.logCustomEvent(withName:"Action: Button \(button.titleLabel)", customAttributes: ["contact_id":contact.id])
         
         switch button {


### PR DESCRIPTION
This pull request includes minor changes to the `BlueButton` styling, per issue [#141](https://github.com/5calls/ios/issues/141). With these changes, buttons will be capitalized (instead of upcased) and will be dark blue upon selection and throughout the call script flow.

Note: I didn't add tests around this functionality, as the unit/ui suites didn't seem to get this granular. Please let me know if tests are required and I can adjust as needed.

Thanks!