### PR TITLE
Native review prompt

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		9C46B1FA1E46EA58009B2C11 /* ReportOutcomeOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C46B1F91E46EA58009B2C11 /* ReportOutcomeOperation.swift */; };
 		AACC2AEB1E732775004B2F2B /* StreakCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACC2AEA1E732775004B2F2B /* StreakCounter.swift */; };
 		AACC2AED1E735144004B2F2B /* StreakCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACC2AEC1E735144004B2F2B /* StreakCounterTests.swift */; };
+		ADB0976A1F8B212800B81661 /* RatingPromptCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB097691F8B212800B81661 /* RatingPromptCounter.swift */; };
 		B13763C171A7D473EE15FAA1 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC9AA735873694488D24C260 /* QuartzCore.framework */; };
 		B50280521E46A7A300749ED7 /* EllipsisButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50280511E46A7A300749ED7 /* EllipsisButton.swift */; };
 		B50280541E46A91F00749ED7 /* AreaOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50280531E46A91F00749ED7 /* AreaOffice.swift */; };
@@ -147,6 +148,7 @@
 		AACC2AEA1E732775004B2F2B /* StreakCounter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StreakCounter.swift; sourceTree = "<group>"; };
 		AACC2AEC1E735144004B2F2B /* StreakCounterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StreakCounterTests.swift; sourceTree = "<group>"; };
 		AC9AA735873694488D24C260 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		ADB097691F8B212800B81661 /* RatingPromptCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingPromptCounter.swift; sourceTree = "<group>"; };
 		AF2A740FE5EBC6A70F2AB3CA /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		B50280511E46A7A300749ED7 /* EllipsisButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EllipsisButton.swift; sourceTree = "<group>"; };
 		B50280531E46A91F00749ED7 /* AreaOffice.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AreaOffice.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 				B5E7626D1E40D72D00D63D62 /* View Models */,
 				B5E7626C1E40D72400D63D62 /* Models */,
 				B52805141E3FA94D00EE832A /* AppDelegate.swift */,
+				ADB097691F8B212800B81661 /* RatingPromptCounter.swift */,
 				B5E98E341E529E66005221B7 /* functions.swift */,
 				B5FFBB981E5EA60E00647121 /* Appearance.swift */,
 				F57BD8B91E438E7600BD554C /* AppearanceProxies.swift */,
@@ -863,6 +866,7 @@
 				9C18DA5D1E457F3D0024B991 /* CallScriptViewController.swift in Sources */,
 				FA1B33A01E485BA3004B9281 /* AboutViewController.swift in Sources */,
 				33C2E0E81E52ADC200F810C6 /* UIColor+FiveCalls.swift in Sources */,
+				ADB0976A1F8B212800B81661 /* RatingPromptCounter.swift in Sources */,
 				271625411E52502D0042222E /* ScheduleRemindersController.swift in Sources */,
 				B502807A1E49864D00749ED7 /* MyImpactViewController.swift in Sources */,
 				B502806A1E48C95700749ED7 /* BorderedButton.swift in Sources */,

--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -62,7 +62,7 @@
 		B5E7625D1E403B8600D63D62 /* StatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E7625C1E403B8600D63D62 /* StatsViewModel.swift */; };
 		B5E7625F1E403C4700D63D62 /* StatsPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E7625E1E403C4700D63D62 /* StatsPageViewController.swift */; };
 		B5E762611E40470100D63D62 /* IssuesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E762601E40470100D63D62 /* IssuesViewController.swift */; };
-		B5E762651E40480300D63D62 /* UserDefaultsKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E762641E40480300D63D62 /* UserDefaultsKeys.swift */; };
+		B5E762651E40480300D63D62 /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E762641E40480300D63D62 /* UserDefaultsKey.swift */; };
 		B5E762671E40CBB600D63D62 /* EditLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E762661E40CBB600D63D62 /* EditLocationViewController.swift */; };
 		B5E762691E40D63800D63D62 /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E762681E40D63800D63D62 /* Issue.swift */; };
 		B5E7626B1E40D6DD00D63D62 /* Contact.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E7626A1E40D6DD00D63D62 /* Contact.swift */; };
@@ -185,7 +185,7 @@
 		B5E7625C1E403B8600D63D62 /* StatsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsViewModel.swift; sourceTree = "<group>"; };
 		B5E7625E1E403C4700D63D62 /* StatsPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsPageViewController.swift; sourceTree = "<group>"; };
 		B5E762601E40470100D63D62 /* IssuesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssuesViewController.swift; sourceTree = "<group>"; };
-		B5E762641E40480300D63D62 /* UserDefaultsKeys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsKeys.swift; sourceTree = "<group>"; };
+		B5E762641E40480300D63D62 /* UserDefaultsKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		B5E762661E40CBB600D63D62 /* EditLocationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditLocationViewController.swift; sourceTree = "<group>"; };
 		B5E762681E40D63800D63D62 /* Issue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		B5E7626A1E40D6DD00D63D62 /* Contact.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Contact.swift; sourceTree = "<group>"; };
@@ -362,7 +362,7 @@
 				B5E98E341E529E66005221B7 /* functions.swift */,
 				B5FFBB981E5EA60E00647121 /* Appearance.swift */,
 				F57BD8B91E438E7600BD554C /* AppearanceProxies.swift */,
-				B5E762641E40480300D63D62 /* UserDefaultsKeys.swift */,
+				B5E762641E40480300D63D62 /* UserDefaultsKey.swift */,
 				2732D7C61E4300F300F149EF /* NotificationNames.swift */,
 				B528051B1E3FA94D00EE832A /* Assets.xcassets */,
 				B528051D1E3FA94D00EE832A /* LaunchScreen.storyboard */,
@@ -845,7 +845,7 @@
 				B5CA63FB1E422D0700966B7D /* IssuesContainerViewController.swift in Sources */,
 				B5E762711E40D8DD00D63D62 /* JSONSerializable.swift in Sources */,
 				B5E7626B1E40D6DD00D63D62 /* Contact.swift in Sources */,
-				B5E762651E40480300D63D62 /* UserDefaultsKeys.swift in Sources */,
+				B5E762651E40480300D63D62 /* UserDefaultsKey.swift in Sources */,
 				D029C6D01F6F42EA00E56CC7 /* Outcome.swift in Sources */,
 				B5E7625F1E403C4700D63D62 /* StatsPageViewController.swift in Sources */,
 				B5D5C95A1E441FEC00C80D5F /* IssuesManager.swift in Sources */,

--- a/FiveCalls/FiveCalls/AboutHtmlViewController.swift
+++ b/FiveCalls/FiveCalls/AboutHtmlViewController.swift
@@ -36,7 +36,7 @@ class AboutHtmlViewController : UIViewController, UIWebViewDelegate {
             // Open links in Safari
             guard let url = request.url else { return true }
             Answers.logCustomEvent(withName: "Action: Open External Link", customAttributes: ["url":url.absoluteString])
-            UIApplication.shared.fvc_open(url)
+            UIApplication.shared.open(url)
             
             return false
         default:

--- a/FiveCalls/FiveCalls/AboutViewController.swift
+++ b/FiveCalls/FiveCalls/AboutViewController.swift
@@ -131,11 +131,3 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
         present(welcomeVC, animated: true)
     }
 }
-
-extension AboutViewController: SKStoreProductViewControllerDelegate {
-    func productViewControllerDidFinish(_ viewController: SKStoreProductViewController) {
-        dismiss(animated: true) {
-            //
-        }
-    }
-}

--- a/FiveCalls/FiveCalls/AboutViewController.swift
+++ b/FiveCalls/FiveCalls/AboutViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import MessageUI
 import CPDAcknowledgements
 import Crashlytics
+import StoreKit
 
 class AboutViewController : UITableViewController, MFMailComposeViewControllerDelegate {
 
@@ -86,8 +87,12 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
     
     func promptForRating() {
         Answers.logCustomEvent(withName: "Action: Rate the App")
-        guard let url = URL(string: "itms-apps://itunes.apple.com/app/viewContentsUserReviews?id=\(AboutViewController.appId)") else { return }
-        UIApplication.shared.fvc_open(url)
+        if #available(iOS 10.3, *) {
+            SKStoreReviewController.requestReview()
+        } else {
+            guard let url = URL(string: "itms-apps://itunes.apple.com/app/viewContentsUserReviews?id=\(AboutViewController.appId)") else { return }
+            UIApplication.shared.fvc_open(url)
+        }
     }
     
     func shareApp(from view: UIView?) {
@@ -124,5 +129,13 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
             self?.dismiss(animated: true, completion: nil)
         }
         present(welcomeVC, animated: true)
+    }
+}
+
+extension AboutViewController: SKStoreProductViewControllerDelegate {
+    func productViewControllerDidFinish(_ viewController: SKStoreProductViewController) {
+        dismiss(animated: true) {
+            //
+        }
     }
 }

--- a/FiveCalls/FiveCalls/AboutViewController.swift
+++ b/FiveCalls/FiveCalls/AboutViewController.swift
@@ -91,7 +91,7 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
             SKStoreReviewController.requestReview()
         } else {
             guard let url = URL(string: "itms-apps://itunes.apple.com/app/viewContentsUserReviews?id=\(AboutViewController.appId)") else { return }
-            UIApplication.shared.fvc_open(url)
+            UIApplication.shared.open(url)
         }
     }
     
@@ -110,7 +110,7 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
     func followOnTwitter() {
         Answers.logCustomEvent(withName: "Action: Follow On Twitter")
         guard let url = URL(string: "https://twitter.com/make5calls") else { return }
-        UIApplication.shared.fvc_open(url)
+        UIApplication.shared.open(url)
     }
     
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {

--- a/FiveCalls/FiveCalls/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         clearNotificationBadge()
         setAppearance()
 
-        resetOrInitializeCallsForRatingIfNecessary()
+        resetOrInitializeCountForRating()
         
         if !UserDefaults.standard.bool(forKey: UserDefaultsKey.hasShownWelcomeScreen.rawValue) {
             showWelcome()
@@ -131,7 +131,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 
-    private func resetOrInitializeCallsForRatingIfNecessary() {
+    private func resetOrInitializeCountForRating() {
         let defaults = UserDefaults.standard
 
         guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }

--- a/FiveCalls/FiveCalls/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppDelegate.swift
@@ -33,7 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         clearNotificationBadge()
         setAppearance()
         
-        if !UserDefaults.standard.bool(forKey: UserDefaultsKeys.hasShownWelcomeScreen.rawValue) {
+        if !UserDefaults.standard.bool(forKey: UserDefaultsKey.hasShownWelcomeScreen.rawValue) {
             showWelcome()
         }
 
@@ -82,7 +82,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let welcomeVC = R.storyboard.welcome.welcomeViewController()!
         let mainVC = window.rootViewController!
         welcomeVC.completionBlock = {
-            UserDefaults.standard.set(true, forKey: UserDefaultsKeys.hasShownWelcomeScreen.rawValue)
+            UserDefaults.standard.set(true, forKey: UserDefaultsKey.hasShownWelcomeScreen.rawValue)
             self.transitionTo(rootViewController: mainVC)
         }
         window.rootViewController = welcomeVC

--- a/FiveCalls/FiveCalls/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppDelegate.swift
@@ -145,16 +145,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         defaults.set(Int(0), forKey: UserDefaultsKey.countOfCallsForRatingPrompt.rawValue)
     }
 }
-
-extension UIApplication {
-    func fvc_open(_ url: URL, completion: ((Bool) -> Void)? = nil) {
-        if #available(iOS 10.0, *) {
-            UIApplication.shared.open(url) {
-                completion?($0)
-            }
-        } else {
-            let result = UIApplication.shared.openURL(url)
-            completion?(result)
-        }
-    }
-}

--- a/FiveCalls/FiveCalls/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppDelegate.swift
@@ -32,6 +32,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         clearNotificationBadge()
         setAppearance()
+
+        resetOrInitializeCallsForRatingIfNecessary()
         
         if !UserDefaults.standard.bool(forKey: UserDefaultsKey.hasShownWelcomeScreen.rawValue) {
             showWelcome()
@@ -126,6 +128,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     private func clearNotificationBadge() {
         UIApplication.shared.applicationIconBadgeNumber = 0
+    }
+
+
+    private func resetOrInitializeCallsForRatingIfNecessary() {
+        let defaults = UserDefaults.standard
+
+        guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return }
+
+        if let storedVersion = defaults.string(forKey: UserDefaultsKey.appVersion.rawValue),
+            currentVersion == storedVersion {
+            return
+        }
+
+        defaults.setValue(currentVersion, forKey: UserDefaultsKey.appVersion.rawValue)
+        defaults.set(Int(0), forKey: UserDefaultsKey.countOfCallsForRatingPrompt.rawValue)
     }
 }
 

--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -102,7 +102,7 @@ class CallScriptViewController : UIViewController, IssueShareable {
         
         if defaults.bool(forKey: firstCallInstructionsKey) {
             guard let dialURL = URL(string: "telprompt:\(number)") else { return }
-            UIApplication.shared.fvc_open(dialURL, completion: callErrorCompletion)
+            UIApplication.shared.open(dialURL, completionHandler: callErrorCompletion)
         } else {
             let alertController = UIAlertController(title: R.string.localizable.firstCallAlertTitle(),
                                                     message:  R.string.localizable.firstCallAlertMessage(),
@@ -117,7 +117,7 @@ class CallScriptViewController : UIViewController, IssueShareable {
                                              style: .default) { _ in
                                                 alertController.dismiss(animated: true, completion: nil)
                                                 guard let dialURL = URL(string: "tel:\(number)") else { return }
-                                                UIApplication.shared.fvc_open(dialURL, completion: callErrorCompletion)
+                                                UIApplication.shared.open(dialURL, completionHandler: callErrorCompletion)
                                                 
                                                 defaults.set(true, forKey: firstCallInstructionsKey)
             }

--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -78,7 +78,7 @@ class CallScriptViewController : UIViewController, IssueShareable {
         self.lastPhoneDialed = number
         
         let defaults = UserDefaults.standard
-        let firstCallInstructionsKey =  UserDefaultsKeys.hasSeenFirstCallInstructions.rawValue
+        let firstCallInstructionsKey =  UserDefaultsKey.hasSeenFirstCallInstructions.rawValue
         
         let callErrorCompletion: (Bool) -> Void = { [weak self] successful in
             if !successful {

--- a/FiveCalls/FiveCalls/CallScriptViewController.swift
+++ b/FiveCalls/FiveCalls/CallScriptViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import CoreLocation
 import Crashlytics
+import StoreKit
 
 class CallScriptViewController : UIViewController, IssueShareable {
     
@@ -22,6 +23,17 @@ class CallScriptViewController : UIViewController, IssueShareable {
         let contactIndex = issue.contacts.index(of: contact)
         return contactIndex == issue.contacts.count - 1
     }
+
+    lazy var ratingPromptCounter: RatingPromptCounter = {
+        let handler: (() -> Void)?
+        if #available(iOS 10.3, *) {
+            handler = { SKStoreReviewController.requestReview() }
+        } else {
+            handler = nil
+        }
+
+        return RatingPromptCounter(handler: handler)
+    }()
     
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var resultInstructionsLabel: UILabel!
@@ -176,6 +188,8 @@ class CallScriptViewController : UIViewController, IssueShareable {
         
         present(alertController, animated: true, completion: nil)
     }
+
+    
 }
 
 enum CallScriptRows : Int {
@@ -274,6 +288,7 @@ extension CallScriptViewController: UICollectionViewDataSource, UICollectionView
 
         if isLastContactForIssue {
             hideResultButtons(animated: true)
+            ratingPromptCounter.increment()
         } else {
             let nextContact = issue.contacts[contactIndex + 1]
             showNextContact(nextContact)

--- a/FiveCalls/FiveCalls/EditLocationViewController.swift
+++ b/FiveCalls/FiveCalls/EditLocationViewController.swift
@@ -113,7 +113,7 @@ class EditLocationViewController : UIViewController, CLLocationManagerDelegate, 
         alertController.addAction(dismiss)
         let openSettings = UIAlertAction(title: R.string.localizable.openSettingsTitle(), style: .default, handler: { action in
             guard let url = URL(string: UIApplicationOpenSettingsURLString) else { return }
-            UIApplication.shared.fvc_open(url)
+            UIApplication.shared.open(url)
         })
         alertController.addAction(openSettings)
         present(alertController, animated: true, completion: nil)

--- a/FiveCalls/FiveCalls/IssueScriptCell.swift
+++ b/FiveCalls/FiveCalls/IssueScriptCell.swift
@@ -19,12 +19,12 @@ class CopyWarningTextView: UITextView {
     @IBOutlet var viewController: UIViewController?
     
     override func copy(_ sender: Any?) {
-        if !UserDefaults.standard.bool(forKey: UserDefaultsKeys.hasWarnedAboutDangersOfCopying.rawValue) {
+        if !UserDefaults.standard.bool(forKey: UserDefaultsKey.hasWarnedAboutDangersOfCopying.rawValue) {
             let alert = UIAlertController(title: R.string.localizable.thinkBeforeCopyingAlertTitle(), message: R.string.localizable.thinkBeforeCopyingAlertBody(), preferredStyle: .alert)
             
             alert.addAction(UIAlertAction(title:  R.string.localizable.okButtonTitle(), style: .cancel, handler: { action in }))
             self.viewController?.present(alert, animated: true, completion: nil)
-            UserDefaults.standard.set(true, forKey: UserDefaultsKeys.hasWarnedAboutDangersOfCopying.rawValue)
+            UserDefaults.standard.set(true, forKey: UserDefaultsKey.hasWarnedAboutDangersOfCopying.rawValue)
         }
         super.copy(sender)
     }

--- a/FiveCalls/FiveCalls/IssuesContainerViewController.swift
+++ b/FiveCalls/FiveCalls/IssuesContainerViewController.swift
@@ -179,7 +179,7 @@ class IssuesContainerViewController : UIViewController, EditLocationViewControll
     }
     
     private func setReminderBellStatus() {
-        let remindersEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.reminderEnabled.rawValue)
+        let remindersEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKey.reminderEnabled.rawValue)
         editRemindersButton.isSelected = remindersEnabled
     }
 }

--- a/FiveCalls/FiveCalls/RatingPromptCounter.swift
+++ b/FiveCalls/FiveCalls/RatingPromptCounter.swift
@@ -1,0 +1,29 @@
+//
+//  RatingPromptCounter.swift
+//  FiveCalls
+//
+//  Created by Abizer Nasir on 09/10/2017.
+//  Copyright © 2017 5calls. All rights reserved.
+//
+
+import Foundation
+
+struct RatingPromptCounter {
+    private let threshold = 5
+
+    let handler: (() -> Void)?
+
+    func increment() {
+        let defaults = UserDefaults.standard
+        let key = UserDefaultsKey.countOfCallsForRatingPrompt.rawValue
+        let count = defaults.integer(forKey: key) + 1
+
+        guard count <= threshold else { return }
+
+        defaults.set(count, forKey: key)
+
+        if count == threshold {
+            handler?()
+        }
+    }
+}

--- a/FiveCalls/FiveCalls/ScheduleRemindersController.swift
+++ b/FiveCalls/FiveCalls/ScheduleRemindersController.swift
@@ -38,9 +38,9 @@ class ScheduleRemindersController: UIViewController {
     }()
     
     private var remindersEnabled: Bool {
-        get { return UserDefaults.standard.bool(forKey: UserDefaultsKeys.reminderEnabled.rawValue) }
+        get { return UserDefaults.standard.bool(forKey: UserDefaultsKey.reminderEnabled.rawValue) }
         set {
-            UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.reminderEnabled.rawValue)
+            UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.reminderEnabled.rawValue)
             if newValue {
                 requestNotificationAccess()
             } else {

--- a/FiveCalls/FiveCalls/UserDefaultsKey.swift
+++ b/FiveCalls/FiveCalls/UserDefaultsKey.swift
@@ -1,5 +1,5 @@
 //
-//  UserDefaultsKeys.swift
+//  UserDefaultsKey.swift
 //  FiveCalls
 //
 //  Created by Ben Scheirman on 1/30/17.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum UserDefaultsKeys : String {
+enum UserDefaultsKey : String {
     case hasShownWelcomeScreen
     
     case locationDisplay

--- a/FiveCalls/FiveCalls/UserDefaultsKey.swift
+++ b/FiveCalls/FiveCalls/UserDefaultsKey.swift
@@ -19,4 +19,7 @@ enum UserDefaultsKey : String {
     case reminderEnabled
 
     case hasWarnedAboutDangersOfCopying
+
+    case appVersion // The current CFBundleShortVersionString
+    case countOfCallsForRatingPrompt
 }

--- a/FiveCalls/FiveCalls/UserLocation.swift
+++ b/FiveCalls/FiveCalls/UserLocation.swift
@@ -33,32 +33,32 @@ class UserLocation {
     var defaults: UserDefaults = .standard
     var locationType: LocationType? {
         get {
-            guard let typeString = defaults.string(forKey: UserDefaultsKeys.locationType.rawValue)
+            guard let typeString = defaults.string(forKey: UserDefaultsKey.locationType.rawValue)
                 else {
                     return nil
                 }
             return LocationType(rawValue: typeString)
         }
         set {
-            defaults.set(newValue?.rawValue, forKey: UserDefaultsKeys.locationType.rawValue)
+            defaults.set(newValue?.rawValue, forKey: UserDefaultsKey.locationType.rawValue)
         }
     }
     
     var locationValue: String? {
         get {
-            return defaults.string(forKey: UserDefaultsKeys.locationValue.rawValue)
+            return defaults.string(forKey: UserDefaultsKey.locationValue.rawValue)
         }
         set {
-            defaults.set(newValue, forKey: UserDefaultsKeys.locationValue.rawValue)
+            defaults.set(newValue, forKey: UserDefaultsKey.locationValue.rawValue)
         }
     }
     
     var locationDisplay: String? {
         get {
-            return defaults.string(forKey: UserDefaultsKeys.locationDisplay.rawValue)
+            return defaults.string(forKey: UserDefaultsKey.locationDisplay.rawValue)
         }
         set {
-            defaults.set(newValue, forKey: UserDefaultsKeys.locationDisplay.rawValue)
+            defaults.set(newValue, forKey: UserDefaultsKey.locationDisplay.rawValue)
         }
     }
     


### PR DESCRIPTION
Fixes #173 and fixes #187 

After the end of the call list has been reached 5 times a native request for a review will be made.

Changes to the way the list of representatives is shown #138 will make this a little more robust.

The number is tracked in the user defaults, and reset when an app update is installed. Since the system takes care of deciding when it is relevant to show the request this doesn't mean that an undue number of requests will be seen.

Also, because the system decides when to show the prompt or not, this is not something that can be tracked. It was my original thought, but I don't think it will work.