### PR TITLE
Fix rotation of the menu bar header

### DIFF
--- a/FiveCalls/FiveCalls/IssuesContainerViewController.swift
+++ b/FiveCalls/FiveCalls/IssuesContainerViewController.swift
@@ -124,8 +124,10 @@ class IssuesContainerViewController : UIViewController, EditLocationViewControll
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        guard splitController.viewControllers.count > 0 else { return }
         coordinator.animate(alongsideTransition: { [unowned self] _ in
-            self.headerContainerConstraint.constant = self.splitController.primaryColumnWidth
+            let showingSideBar = self.splitController.isCollapsed
+            self.headerContainerConstraint.constant = !showingSideBar ? self.splitController.primaryColumnWidth : 0
         })
     }
     


### PR DESCRIPTION
Fixes #218 - funky menu bar header on rotation for plus sized devices. 

Now I check the previous state of the Split Controller to do the following:
* Not run the code if it's not needed (no split view controller)
* Change the offset of the menu bar based on the `isCollapsed` state which turns off on rotation.

I tested this across many devices, seems to work better across them all now. 