### PR TITLE
Use the server's value for streaks if available

### DIFF
--- a/FiveCalls/FiveCalls/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppDelegate.swift
@@ -28,8 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Fabric.with([Crashlytics.self])
 
         migrateSavedData()
-        
-        
+
         Pantry.useApplicationSupportDirectory = true
 
         clearNotificationBadge()

--- a/FiveCalls/FiveCalls/FetchUserStatsOperation.swift
+++ b/FiveCalls/FiveCalls/FetchUserStatsOperation.swift
@@ -13,6 +13,8 @@ class FetchUserStatsOperation : BaseOperation {
     class TokenExpiredError : Error { }
     
     var userStats: UserStats?
+    var weeklyStreak: Int?
+    var firstCallTime: Date?
     var httpResponse: HTTPURLResponse?
     var error: Error?
     
@@ -88,7 +90,10 @@ class FetchUserStatsOperation : BaseOperation {
         //    "contact": 221,
         //    "voicemail": 158,
         //    "unavailable": 32
-        // } }
+        //   },
+        //   weeklyStreak: 10,
+        //   firstCallTime: 1487959763
+        // }
         guard let wrapper = try JSONSerialization.jsonObject(with: data, options: []) as? [String:AnyObject] else {
             print("Couldn't parse JSON data.")
             return
@@ -97,6 +102,14 @@ class FetchUserStatsOperation : BaseOperation {
         if let statsDictionary = wrapper["stats"] as? JSONDictionary {
             userStats = UserStats(dictionary: statsDictionary)
         }
+
+        if let streakCount = wrapper["weeklyStreak"] as? Int {
+            weeklyStreak = streakCount
+        }
+
+//        if let firstCallUnixSeconds = wrapper["firstCallTime"] as? Double {
+//            firstCallTime = Date(timeIntervalSince1970: firstCallUnixSeconds)
+//        }
     }
 }
 

--- a/FiveCalls/FiveCalls/FetchUserStatsOperation.swift
+++ b/FiveCalls/FiveCalls/FetchUserStatsOperation.swift
@@ -13,7 +13,6 @@ class FetchUserStatsOperation : BaseOperation {
     class TokenExpiredError : Error { }
     
     var userStats: UserStats?
-    var weeklyStreak: Int?
     var firstCallTime: Date?
     var httpResponse: HTTPURLResponse?
     var error: Error?
@@ -99,12 +98,8 @@ class FetchUserStatsOperation : BaseOperation {
             return
         }
 
-        if let statsDictionary = wrapper["stats"] as? JSONDictionary {
+        if let statsDictionary = wrapper as? JSONDictionary {
             userStats = UserStats(dictionary: statsDictionary)
-        }
-
-        if let streakCount = wrapper["weeklyStreak"] as? Int {
-            weeklyStreak = streakCount
         }
 
         if let firstCallUnixSeconds = wrapper["firstCallTime"] as? Double {

--- a/FiveCalls/FiveCalls/FetchUserStatsOperation.swift
+++ b/FiveCalls/FiveCalls/FetchUserStatsOperation.swift
@@ -107,9 +107,9 @@ class FetchUserStatsOperation : BaseOperation {
             weeklyStreak = streakCount
         }
 
-//        if let firstCallUnixSeconds = wrapper["firstCallTime"] as? Double {
-//            firstCallTime = Date(timeIntervalSince1970: firstCallUnixSeconds)
-//        }
+        if let firstCallUnixSeconds = wrapper["firstCallTime"] as? Double {
+            firstCallTime = Date(timeIntervalSince1970: firstCallUnixSeconds)
+        }
     }
 }
 

--- a/FiveCalls/FiveCalls/ImpactViewModel.swift
+++ b/FiveCalls/FiveCalls/ImpactViewModel.swift
@@ -40,4 +40,30 @@ struct ImpactViewModel {
         let logDates = logs.all.map { $0.date }
         return StreakCounter(dates: logDates, referenceDate: Date()).weekly
     }
+
+    var weeklyStreakMessage: String {
+        // use the server weekly streak if available
+        let weeklyStreakCount = self.userStats?.weeklyStreak ?? self.weeklyStreakCount
+
+        switch weeklyStreakCount {
+        case 0:
+            return R.string.localizable.yourWeeklyStreakZero(weeklyStreakCount)
+        case 1:
+            return R.string.localizable.yourWeeklyStreakSingle()
+        default:
+            return R.string.localizable.yourWeeklyStreakMultiple(weeklyStreakCount)
+        }
+    }
+
+    var impactMessage: String {
+        switch self.numberOfCalls {
+        case 0:
+            return R.string.localizable.yourImpactZero(numberOfCalls)
+        case 1:
+            return R.string.localizable.yourImpactSingle(numberOfCalls)
+        default:
+            return R.string.localizable.yourImpactMultiple(numberOfCalls)
+        }
+    }
+
 }

--- a/FiveCalls/FiveCalls/MyImpactViewController.swift
+++ b/FiveCalls/FiveCalls/MyImpactViewController.swift
@@ -15,6 +15,7 @@ class MyImpactViewController : UITableViewController {
     
     private var viewModel: ImpactViewModel!
     private var userStats: UserStats?
+    private var weeklyStreak: Int?
     private var totalCalls: Int?
     
     @IBOutlet weak var navSignInButton: UIBarButtonItem!
@@ -103,14 +104,19 @@ class MyImpactViewController : UITableViewController {
     
     func displayStats() {
         viewModel = ImpactViewModel(logs: ContactLogs.load(), stats: userStats)
-        let weeklyStreakCount = viewModel.weeklyStreakCount
+
+        // use the server weekly streak if we have it
+        let weeklyStreakCount = self.weeklyStreak ?? viewModel.weeklyStreakCount
         streakLabel.text = weeklyStreakMessage(for: weeklyStreakCount)
+
         let numberOfCalls = viewModel.numberOfCalls
         impactLabel.text = impactMessage(for: numberOfCalls)
+
         if numberOfCalls == 0 {
             subheadLabel.isHidden = true
             subheadLabel.addConstraint(NSLayoutConstraint(item: subheadLabel, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 0))
         }
+
         tableView.reloadData()
     }
     
@@ -156,6 +162,7 @@ class MyImpactViewController : UITableViewController {
             let userStatsOp = FetchUserStatsOperation()
             userStatsOp.completionBlock = {
                 self.userStats = userStatsOp.userStats
+                self.weeklyStreak = userStatsOp.weeklyStreak
                 DispatchQueue.main.async {
                     self.displayStats()
                 }

--- a/FiveCalls/FiveCalls/MyImpactViewController.swift
+++ b/FiveCalls/FiveCalls/MyImpactViewController.swift
@@ -15,7 +15,6 @@ class MyImpactViewController : UITableViewController {
     
     private var viewModel: ImpactViewModel!
     private var userStats: UserStats?
-    private var weeklyStreak: Int?
     private var totalCalls: Int?
     
     @IBOutlet weak var navSignInButton: UIBarButtonItem!
@@ -105,14 +104,10 @@ class MyImpactViewController : UITableViewController {
     func displayStats() {
         viewModel = ImpactViewModel(logs: ContactLogs.load(), stats: userStats)
 
-        // use the server weekly streak if we have it
-        let weeklyStreakCount = self.weeklyStreak ?? viewModel.weeklyStreakCount
-        streakLabel.text = weeklyStreakMessage(for: weeklyStreakCount)
+        streakLabel.text = viewModel.weeklyStreakMessage
+        impactLabel.text = viewModel.impactMessage
 
-        let numberOfCalls = viewModel.numberOfCalls
-        impactLabel.text = impactMessage(for: numberOfCalls)
-
-        if numberOfCalls == 0 {
+        if viewModel.numberOfCalls == 0 {
             subheadLabel.isHidden = true
             subheadLabel.addConstraint(NSLayoutConstraint(item: subheadLabel, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 0))
         }
@@ -162,7 +157,6 @@ class MyImpactViewController : UITableViewController {
             let userStatsOp = FetchUserStatsOperation()
             userStatsOp.completionBlock = {
                 self.userStats = userStatsOp.userStats
-                self.weeklyStreak = userStatsOp.weeklyStreak
                 DispatchQueue.main.async {
                     self.displayStats()
                 }
@@ -212,28 +206,6 @@ class MyImpactViewController : UITableViewController {
         return R.string.localizable.communityCalls(statsVm.formattedNumberOfCalls)
     }
 
-    private func weeklyStreakMessage(for weeklyStreakCount: Int) -> String {
-        switch weeklyStreakCount {
-        case 0:
-            return R.string.localizable.yourWeeklyStreakZero(weeklyStreakCount)
-        case 1:
-            return R.string.localizable.yourWeeklyStreakSingle()
-        default:
-            return R.string.localizable.yourWeeklyStreakMultiple(weeklyStreakCount)
-        }
-    }
-  
-    private func impactMessage(for numberOfCalls: Int) -> String {
-        switch numberOfCalls {
-        case 0:
-            return R.string.localizable.yourImpactZero(numberOfCalls)
-        case 1:
-            return R.string.localizable.yourImpactSingle(numberOfCalls)
-        default:
-            return R.string.localizable.yourImpactMultiple(numberOfCalls)
-        }
-    }
-  
     private func configureStatRow(cell: UITableViewCell, stat: StatRow) {
         switch stat {
         case .madeContact:

--- a/FiveCalls/FiveCalls/UserStats.swift
+++ b/FiveCalls/FiveCalls/UserStats.swift
@@ -17,14 +17,26 @@ struct UserStats {
     let contact: Int?
     let voicemail: Int?
     let unavailable: Int?
+    let weeklyStreak: Int?
 }
 
 extension UserStats : JSONSerializable {
     init?(dictionary: JSONDictionary) {
-        let contact = dictionary["contact"] as? Int
-        let voicemail = dictionary["voicemail"] as? Int
-        let unavailable = dictionary["unavailable"] as? Int
-        self.init(contact: contact, voicemail: voicemail, unavailable: unavailable)
+        let weeklyStreak = dictionary["weeklyStreak"] as? Int
+
+        var contact: Int?
+        var voicemail: Int?
+        var unavailable: Int?
+        if let stats = dictionary["stats"] as? JSONDictionary {
+            contact = stats["contact"] as? Int
+            voicemail = stats["voicemail"] as? Int
+            unavailable = stats["unavailable"] as? Int
+        }
+
+        self.init(contact: contact,
+                  voicemail: voicemail,
+                  unavailable: unavailable,
+                  weeklyStreak: weeklyStreak)
     }
     
     func totalCalls() -> Int {


### PR DESCRIPTION
Two new values from the stats endpoint:

* The number of streak weeks
* The time of the first recorded call for this user

We don't currently use the second in iOS, but on the web it powers a field that says "Making calls since May 2017" or some such.