### PR TITLE
Align Gemfile.lock & Podspec.lock cocoapods version to 1.5.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "cocoapods"
+gem "cocoapods", "1.5.3"
 gem "cocoapods-acknowledgements"
 gem "dotenv"
 gem "fastlane"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,10 +17,10 @@ GEM
       fastlane (>= 2.0)
       mini_magick (>= 4.5)
     claide (1.0.2)
-    cocoapods (1.5.0)
+    cocoapods (1.5.3)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.5.0)
+      cocoapods-core (= 1.5.3)
       cocoapods-deintegrate (>= 1.0.2, < 2.0)
       cocoapods-downloader (>= 1.2.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -39,17 +39,17 @@ GEM
     cocoapods-acknowledgements (1.1.2)
       activesupport (>= 4.0.2, < 5)
       redcarpet (~> 3.3)
-    cocoapods-core (1.5.0)
+    cocoapods-core (1.5.3)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.2)
-    cocoapods-downloader (1.2.0)
+    cocoapods-downloader (1.2.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
     cocoapods-stats (1.0.0)
-    cocoapods-trunk (1.3.0)
+    cocoapods-trunk (1.3.1)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.1.0)
@@ -147,7 +147,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_magick (4.5.1)
     minitest (5.11.3)
-    molinillo (0.6.5)
+    molinillo (0.6.6)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -165,7 +165,7 @@ GEM
       uber (< 0.2.0)
     retriable (3.1.1)
     rouge (2.0.7)
-    ruby-macho (1.1.0)
+    ruby-macho (1.3.1)
     rubyzip (1.2.1)
     security (0.1.3)
     signet (0.8.1)
@@ -209,10 +209,10 @@ PLATFORMS
 
 DEPENDENCIES
   badge
-  cocoapods
+  cocoapods (= 1.5.3)
   cocoapods-acknowledgements
   dotenv
   fastlane
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
Just checking out the project and noticed that the bundled version of Cocoapods is 1.5.0
where as the [Podspec.lock](https://github.com/5calls/ios/blob/92a84c7dd1e6004a4ee46c9312e46fe5d78af7e7/FiveCalls/Podfile.lock#L90) version is 1.5.3 on master.

Seems sensible to bump the bundled version to 1.5.3, unless anyone has any objections.