### PR TITLE
Dynamic type support - Issue Detail & Call Script

### DIFF
--- a/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
@@ -381,7 +381,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="122"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SPEAK OUT FOR ENVIRONMENTAL IMPACT AT STANDING ROCK" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IJo-u6-qUp">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SPEAK OUT FOR ENVIRONMENTAL IMPACT AT STANDING ROCK" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IJo-u6-qUp">
                                                     <rect key="frame" x="15" y="14" width="290" height="94"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
@@ -413,7 +413,7 @@
                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="300" id="Dck-pa-5UE"/>
                                                     </constraints>
                                                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                     <connections>
                                                         <outlet property="delegate" destination="tFw-k8-nYx" id="6cz-aV-1dZ"/>

--- a/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
@@ -588,13 +588,13 @@
                                                         <constraint firstAttribute="height" constant="80" id="qMn-6O-XeZ"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Richard J. Durbin D-IL with a long name that wraps" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NoE-J1-wgV">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Richard J. Durbin D-IL with a long name that wraps" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NoE-J1-wgV">
                                                     <rect key="frame" x="15" y="37" width="202" height="64.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                     <color key="textColor" red="0.095469482243061066" green="0.45810282230377197" blue="0.8193671703338623" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Call this office:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="avw-nh-C54">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Call this office:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="avw-nh-C54">
                                                     <rect key="frame" x="15" y="15" width="85" height="18"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="18" id="emy-7c-NxZ"/>
@@ -603,9 +603,9 @@
                                                     <color key="textColor" red="0.09546948224" green="0.45810282229999999" blue="0.81936717029999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is one of your two senators" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Voe-9n-8a4">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is one of your two senators" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Voe-9n-8a4">
                                                     <rect key="frame" x="15" y="156" width="195" height="16"/>
-                                                    <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="16"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                     <color key="textColor" red="0.09546948224" green="0.45810282229999999" blue="0.81936717029999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>

--- a/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
@@ -409,9 +409,6 @@
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sBt-Uw-7vs">
                                                     <rect key="frame" x="15" y="11" width="290" height="300"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="300" id="Dck-pa-5UE"/>
-                                                    </constraints>
                                                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -439,37 +436,36 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-office" translatesAutoresizingMaskIntoConstraints="NO" id="JQD-W8-GS8">
-                                                    <rect key="frame" x="25" y="16" width="80" height="80"/>
+                                                    <rect key="frame" x="25" y="13.5" width="80" height="80"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="80" id="Tc1-QS-PDh"/>
                                                         <constraint firstAttribute="height" constant="80" id="gRy-8w-BsQ"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="John Cornyn" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="10" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EGt-v6-UFC">
-                                                    <rect key="frame" x="113" y="30" width="123" height="23"/>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="John Cornyn" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EGt-v6-UFC">
+                                                    <rect key="frame" x="113" y="30.5" width="111.5" height="24"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                     <color key="textColor" red="0.36615640862944165" green="0.36615640862944165" blue="0.36615640862944165" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Senate • Republican • TX" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2w7-0y-u2B">
-                                                    <rect key="frame" x="113" y="55" width="185" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Senate • Republican • TX" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2w7-0y-u2B">
+                                                    <rect key="frame" x="113" y="57.5" width="185" height="18.5"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                     <color key="textColor" red="0.56095336294416243" green="0.56095336294416243" blue="0.56095336294416243" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="EGt-v6-UFC" secondAttribute="trailing" constant="5" id="7bb-LJ-0Xe"/>
-                                                <constraint firstItem="2w7-0y-u2B" firstAttribute="top" secondItem="r0i-yC-dN5" secondAttribute="top" constant="55" id="NWn-fc-P6o"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="JQD-W8-GS8" secondAttribute="bottom" constant="6" id="PMq-LZ-mnE"/>
+                                                <constraint firstItem="EGt-v6-UFC" firstAttribute="top" secondItem="r0i-yC-dN5" secondAttribute="top" constant="30" id="Dv8-Wj-2Er"/>
                                                 <constraint firstAttribute="trailing" secondItem="2w7-0y-u2B" secondAttribute="trailing" constant="22" id="PZj-ED-A5V"/>
                                                 <constraint firstItem="JQD-W8-GS8" firstAttribute="leading" secondItem="r0i-yC-dN5" secondAttribute="leadingMargin" constant="10" id="Ylr-8C-83v"/>
+                                                <constraint firstItem="JQD-W8-GS8" firstAttribute="centerY" secondItem="r0i-yC-dN5" secondAttribute="centerY" id="ZsB-Cy-NHz"/>
                                                 <constraint firstItem="2w7-0y-u2B" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="EGt-v6-UFC" secondAttribute="leading" id="ZwD-mG-arU"/>
-                                                <constraint firstItem="EGt-v6-UFC" firstAttribute="top" secondItem="JQD-W8-GS8" secondAttribute="top" constant="14" id="csQ-05-xKc"/>
                                                 <constraint firstItem="2w7-0y-u2B" firstAttribute="top" secondItem="EGt-v6-UFC" secondAttribute="bottom" constant="2.5" id="efc-or-EIc"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="2w7-0y-u2B" secondAttribute="bottom" constant="20" id="nUh-F3-i8A"/>
+                                                <constraint firstItem="2w7-0y-u2B" firstAttribute="leading" secondItem="EGt-v6-UFC" secondAttribute="leading" id="o1n-XK-YkS"/>
                                                 <constraint firstItem="EGt-v6-UFC" firstAttribute="leading" secondItem="JQD-W8-GS8" secondAttribute="trailing" constant="8" id="suA-wa-7jG"/>
-                                                <constraint firstItem="JQD-W8-GS8" firstAttribute="top" secondItem="r0i-yC-dN5" secondAttribute="topMargin" constant="5" id="sy0-TZ-Zw2"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" red="0.96070033310000003" green="0.96083813910000004" blue="0.96067017320000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -487,9 +483,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="65.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Set your location to find your representatives" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Pe-Fz-TPy">
-                                                    <rect key="frame" x="13" y="23" width="291" height="20.5"/>
-                                                    <fontDescription key="fontDescription" name="HelveticaNeue-CondensedBold" family="Helvetica Neue" pointSize="19"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Set your location to find your representatives" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Pe-Fz-TPy">
+                                                    <rect key="frame" x="20" y="26" width="277" height="15"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                     <color key="textColor" red="1" green="0.00033646567799999999" blue="0.13182058469999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>

--- a/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
@@ -615,6 +615,12 @@
                                                     <state key="normal" title="Local Offices">
                                                         <color key="titleColor" red="0.89566051959991455" green="0.2254079282283783" blue="0.20752480626106262" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="titleLabel.adjustsFontForContentSizeCategory" value="YES"/>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="titleLabel.numberOfLines">
+                                                            <integer key="value" value="2"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pkr-8w-SY8">
                                                     <rect key="frame" x="15" y="109.5" width="168" height="36"/>
@@ -622,6 +628,9 @@
                                                     <state key="normal" title="+1 444-444-4444">
                                                         <color key="titleColor" red="0.89566051960000004" green="0.2254079282" blue="0.2075248063" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="titleLabel.adjustsFontForContentSizeCategory" value="YES"/>
+                                                    </userDefinedRuntimeAttributes>
                                                 </button>
                                             </subviews>
                                             <constraints>

--- a/FiveCalls/FiveCalls/issuesStyle.css
+++ b/FiveCalls/FiveCalls/issuesStyle.css
@@ -1,15 +1,12 @@
 /* not a lot is supported here, so we try our best */
 body {
+    font: -apple-system-body;
     font-family: -apple-system, sans-serif;
 }
 a {
     color: #e53935;
 }
-p {
-    font-size: 18px;
-}
 li {
-    font-size: 18px;
     margin: 0 0 0.5rem 0;
 }
 blockquote {


### PR DESCRIPTION
**Updated 10 Oct 18**

This PR adds basic Dynamic Type support (#144) to the IssueDetailViewController & CallScriptViewController.

## Approach

The changes for full Dynamic Type support are going to land up touching each screen so I'd suggest we break this into multiple PR's if that sounds good with everyone? There are a lot of Gotchas when trying to support the Extra large AX1 - AX5 sizes so I'd suggest we break this down as follows:

* Pull Request into master for 1-2 screens at a time
* First iteration -> Best effort to support xSmall -> xxxLarge with minimal refactoring. (Largely storyboard changes)
* Future iterations -> Improvements to AX1-AX5 font sizes or that require larger code changes (Moving to StackViews, etc)
* I'd like to suggest we ignore visual defects that:
    * are only reproducible when changing Dynamic Type while a ViewController is on screen. This is such a low usage scenario that it’s not worth focusing on imho. 
    * only occur at the extra large sizes AX1-AX5 for the first few passes.

Does that sound like a reasonable approach to everyone?

## Changes in the PR

|Screen | small | xxxLarge |
| --- | --- | --- |
| Issue Detail | <img width="231" alt="detail-small" src="https://user-images.githubusercontent.com/993745/46763134-f4f8a580-ccd0-11e8-8e9c-3f2903cb1d58.png"> | <img width="231" alt="detail-xxxlarge" src="https://user-images.githubusercontent.com/993745/46763146-fc1fb380-ccd0-11e8-8bfb-788799f9a577.png"> |
| Issue Detail + profile | <img width="231" alt="detail-profile-small" src="https://user-images.githubusercontent.com/993745/46763167-0772df00-ccd1-11e8-9351-1796e57299d3.png"> | <img width="231" alt="detail-profile-xxxlarge" src="https://user-images.githubusercontent.com/993745/46763183-122d7400-ccd1-11e8-95fe-9d752d175c77.png"> |
| Call Page | <img width="231" alt="call-small" src="https://user-images.githubusercontent.com/993745/46763202-1e193600-ccd1-11e8-9cb8-d41f20c712ae.png"> | <img width="231" alt="call-large" src="https://user-images.githubusercontent.com/993745/46763207-22455380-ccd1-11e8-8d31-c3410475eed2.png"> |

## Deferred to later

* The Call Script page uses a collectionView for the dynamic buttons. To support dynamic height here we'd either have to look at resizable CollectionViewCells or potentially move to a simpler Stack View layout that can easily switch between a grid and a vertical stack.
* The Call Script header breaks down at AX2

