### PR TITLE
Convert to UNUserNotifications

### DIFF
--- a/FiveCalls/FiveCalls/ScheduleRemindersController.swift
+++ b/FiveCalls/FiveCalls/ScheduleRemindersController.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UserNotifications
 
 class ScheduleRemindersController: UIViewController {
 
@@ -65,10 +66,10 @@ class ScheduleRemindersController: UIViewController {
     }
 
     private func requestNotificationAccess() {
-        UIApplication.shared.registerUserNotificationSettings(
-            UIUserNotificationSettings(types: [.alert, .badge],
-                                       categories: nil)
-        )
+        let options: UNAuthorizationOptions = [.alert, .sound, .badge];
+        UNUserNotificationCenter.current().requestAuthorization(options: options) { (success, error) in
+            // ok
+        }
     }
 
     func setOverlay(visible: Bool, animated: Bool) {
@@ -99,12 +100,17 @@ class ScheduleRemindersController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        if let notifications = UIApplication.shared.scheduledLocalNotifications {
-            daysOfWeekSelector.setSelectedButtons(at: indices(from: notifications))
-            if let date = notifications.first?.fireDate {
-                timePicker.setDate(date, animated: true)
+        UNUserNotificationCenter.current().getPendingNotificationRequests { [weak self] (notificationRequests) in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                self.daysOfWeekSelector.setSelectedButtons(at: self.indices(from: notificationRequests))
+                if let trigger = notificationRequests.first?.trigger as? UNCalendarNotificationTrigger {
+                    self.timePicker.setDate(trigger.nextTriggerDate() ?? Date(), animated: true)
+                }
+                self.updateDaysWarning()
             }
         }
+
         if navigationController?.viewControllers.first == self {
             let item = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissAction(_:)))
             item.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: .normal)
@@ -121,7 +127,6 @@ class ScheduleRemindersController: UIViewController {
         super.viewWillAppear(animated)
         daysOfWeekSelector.warningBorderColor = UIColor.fvc_red.cgColor
         noDaysWarningLabel.textColor = .fvc_red
-        updateDaysWarning()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -129,9 +134,14 @@ class ScheduleRemindersController: UIViewController {
         guard notificationsChanged == true && remindersEnabled else { return }
 
         clearNotifications()
-        for selectorIndex in daysOfWeekSelector.selectedIndices {
-            let localNotif = createNotification(with: selectorIndex, chosenTime: timePicker.date)
-            UIApplication.shared.scheduleLocalNotification(localNotif)
+        for index in daysOfWeekSelector.selectedIndices {
+            let notificationContent = createNotification()
+            var components = Calendar.current.dateComponents([.hour,.minute,.second], from: timePicker.date)
+            components.timeZone = TimeZone(identifier: "default")
+            components.weekday = index + 2
+            let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+            let request = UNNotificationRequest(identifier: "5calls-reminder-\(index)", content: notificationContent, trigger: trigger)
+            UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
         }
     }
 
@@ -145,7 +155,7 @@ class ScheduleRemindersController: UIViewController {
     }
     
     private func clearNotifications() {
-        UIApplication.shared.cancelAllLocalNotifications()
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
     }
 
     @IBAction func timePickerChanged(_ sender: UIDatePicker) {
@@ -159,8 +169,10 @@ class ScheduleRemindersController: UIViewController {
 
     func updateDaysWarning() {
         if daysOfWeekSelector.selectedIndices.count == 0 {
+            daysOfWeekSelector.warningBorderColor = UIColor.fvc_red.cgColor
             noDaysWarningLabel.isHidden = false
         } else {
+            daysOfWeekSelector.warningBorderColor = nil
             noDaysWarningLabel.isHidden = true
         }
     }
@@ -179,9 +191,15 @@ class ScheduleRemindersController: UIViewController {
         }
     }
 
-    private func indices(from notifications: [UILocalNotification]) -> [Int] {
+    private func indices(from notifications: [UNNotificationRequest]) -> [Int] {
         let calendar = Calendar(identifier: .gregorian)
-        return notifications.compactMap({ return calendar.component(.weekday, from: ($0.fireDate)!) - 2})
+        return notifications.compactMap({ notification in
+            if let calendarTrigger = notification.trigger as? UNCalendarNotificationTrigger {
+                return calendar.component(.weekday, from: (calendarTrigger.nextTriggerDate()!)) - 2
+            }
+            
+            return nil
+        })
     }
 
     private func fireDate(for index: Int, date: Date) -> Date? {
@@ -197,16 +215,22 @@ class ScheduleRemindersController: UIViewController {
         return calendar.date(from: dateComponents)
     }
 
-    private func createNotification(with index: Int, chosenTime: Date) -> UILocalNotification {
-        let localNotif = UILocalNotification()
-        localNotif.fireDate = fireDate(for: index, date: chosenTime)
-        localNotif.alertTitle = R.string.localizable.scheduledReminderAlertTitle()
-        localNotif.alertBody = R.string.localizable.scheduledReminderAlertBody()
-        localNotif.repeatInterval = .weekOfYear
-        localNotif.alertAction = R.string.localizable.okButtonTitle()
-        localNotif.timeZone = TimeZone(identifier: "default")
-        localNotif.applicationIconBadgeNumber = UIApplication.shared.applicationIconBadgeNumber + 1
-        return localNotif
+    private func createNotification() -> UNMutableNotificationContent {
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.title = R.string.localizable.scheduledReminderAlertTitle()
+        notificationContent.body = R.string.localizable.scheduledReminderAlertBody()
+        notificationContent.badge = NSNumber(value: UIApplication.shared.applicationIconBadgeNumber + 1)
+        return notificationContent
+        
+//        let localNotif = UILocalNotification()
+//        • localNotif.fireDate = fireDate(for: index, date: chosenTime)
+//         localNotif.alertTitle = R.string.localizable.scheduledReminderAlertTitle()
+//        localNotif.alertBody = R.string.localizable.scheduledReminderAlertBody()
+//        localNotif.repeatInterval = .weekOfYear
+//        localNotif.alertAction = R.string.localizable.okButtonTitle()
+//        localNotif.timeZone = TimeZone(identifier: "default")
+//        localNotif.applicationIconBadgeNumber = UIApplication.shared.applicationIconBadgeNumber + 1
+//        return localNotif
     }
 
 


### PR DESCRIPTION
Existing user notifications are carried over! That makes things easier. Fixes #240 

This does the very basic conversion to the non-deprecated API. We should probably allow reminding on weekends in the future too.