### PR TITLE
Wait a few minutes before backfilling unreported stats

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -795,7 +795,7 @@
 			);
 			name = "Generate R.Swift Code";
 			outputPaths = (
-				$SRCROOT/R.generated.swift,
+				"$SRCROOT/R.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/FiveCalls/Podfile
+++ b/FiveCalls/Podfile
@@ -9,7 +9,7 @@ end
 
 target 'FiveCalls' do
   common_pods
-  pod 'Auth0', '~> 1.15', inhibit_warnings: true
+  pod 'Auth0', '~> 1.19', inhibit_warnings: true
   pod 'CPDAcknowledgements', git: 'https://github.com/CocoaPods/CPDAcknowledgements.git'
   pod 'DZNEmptyDataSet', git: 'https://github.com/subdigital/DZNEmptyDataSet'
   pod 'Kingfisher', '~> 4.0'

--- a/FiveCalls/Podfile.lock
+++ b/FiveCalls/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - AppCenter/Core (2.0.1)
   - AppCenter/Crashes (2.0.1):
     - AppCenter/Core
-  - Auth0 (1.15.0):
+  - Auth0 (1.19.3):
     - SimpleKeychain
   - CPDAcknowledgements (1.0.0)
   - Down (0.5.2)
@@ -30,7 +30,7 @@ PODS:
 
 DEPENDENCIES:
   - AppCenter
-  - Auth0 (~> 1.15)
+  - Auth0 (~> 1.17)
   - CPDAcknowledgements (from `https://github.com/CocoaPods/CPDAcknowledgements.git`)
   - Down
   - DZNEmptyDataSet (from `https://github.com/subdigital/DZNEmptyDataSet`)
@@ -42,13 +42,14 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AppCenter
-    - Auth0
     - Down
     - Kingfisher
     - OneSignal
     - PromiseKit
     - R.swift
     - R.swift.Library
+  trunk:
+    - Auth0
     - SimpleKeychain
 
 EXTERNAL SOURCES:
@@ -67,7 +68,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   AppCenter: 6a5ff2fd007b53431259fdd74f91eb3d0dfea3d1
-  Auth0: b741c805711a80eb698fce55d354cc32e0784dce
+  Auth0: 195ea089de471c72bf95eb5320ff86c224debf3c
   CPDAcknowledgements: 6e15e71849ba4ad5e8a17a0bb9d20938ad23bac8
   Down: 587371ad58002b06023d9c602519216862c3acbc
   DZNEmptyDataSet: b94434220f87d9dda46660eb4f07a424778e93b4
@@ -78,6 +79,6 @@ SPEC CHECKSUMS:
   R.swift.Library: cfe85d569d9bae6cb262922db130e7c3a7a5fad1
   SimpleKeychain: 3be49072fd2d82de8fa83d847ef1e548622f8fc5
 
-PODFILE CHECKSUM: 5d8c0bcc03b1bb067cdf57dde0fa26882153fd76
+PODFILE CHECKSUM: 4cb8dc1b7061d9d6ccbfc7db606299667bda4c68
 
 COCOAPODS: 1.8.4

--- a/FiveCalls/Pods/Auth0/Auth0/AuthSession.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/AuthSession.swift
@@ -59,7 +59,7 @@ class AuthSession: NSObject, AuthTransaction {
                 self.finish(.failure(error: AuthenticationError(string: url.absoluteString, statusCode: 200)))
                 return false
             }
-        var items = self.handler.values(fromComponents: components)
+        let items = self.handler.values(fromComponents: components)
         guard has(state: self.state, inItems: items) else { return false }
         if items["error"] != nil {
             self.finish(.failure(error: AuthenticationError(info: items, statusCode: 0)))

--- a/FiveCalls/Pods/Auth0/Auth0/Authentication.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/Authentication.swift
@@ -146,6 +146,40 @@ public protocol Authentication: Trackable, Loggable {
     func login(withOTP otp: String, mfaToken: String) -> Request<Credentials, AuthenticationError>
 
     /**
+     Login using username and password in the default directory
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .loginDefaultDirectory(
+     withUsername: "support@auth0.com",
+     password: "a secret password")
+     ```
+     
+     You can also specify audience and scope
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .loginDefaultDirectory(
+     withUsername: "support@auth0.com",
+     password: "a secret password",
+     audience: "https://myapi.com/api",
+     scope: "openid profile")
+     ```
+     
+     - parameter username:    username or email used of the user to authenticate
+     - parameter password:    password of the user
+     - parameter audience:    API Identifier that the client is requesting access to.
+     - parameter scope:       scope value requested when authenticating the user.
+     - parameter parameters:  additional parameters that are optionally sent with the authentication request
+     
+     - important: This only works if you have the OAuth 2.0 API Authorization flag on
+     - returns: authentication request that will yield Auth0 User Credentials
+     */
+    func loginDefaultDirectory(withUsername username: String, password: String, audience: String?, scope: String?, parameters: [String: Any]?) -> Request<Credentials, AuthenticationError>
+
+    /**
      Creates a user in a Database connection
 
      ```
@@ -155,7 +189,7 @@ public protocol Authentication: Trackable, Loggable {
         .start { print($0) }
      ```
 
-     you can also add additional attributes when creating the user
+     you can also add additional metadata when creating the user
 
      ```
      Auth0
@@ -178,10 +212,12 @@ public protocol Authentication: Trackable, Loggable {
      - parameter password:          password for the new user
      - parameter connection:        name where the user will be created (Database connection)
      - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
-
+     - parameter rootAttributes:    root attributes that will be added to the newly created user. See https://auth0.com/docs/api/authentication#signup for supported attributes. Will not overwrite existing parameters.
+     
      - returns: request that will yield a created database user (just email, username and email verified flag)
      */
-    func createUser(email: String, username: String?, password: String, connection: String, userMetadata: [String: Any]?) -> Request<DatabaseUser, AuthenticationError>
+    // swiftlint:disable:next function_parameter_count
+    func createUser(email: String, username: String?, password: String, connection: String, userMetadata: [String: Any]?, rootAttributes: [String: Any]?) -> Request<DatabaseUser, AuthenticationError>
 
     /**
      Resets a Database user password
@@ -600,6 +636,42 @@ public extension Authentication {
     }
 
     /**
+     Login using username and password in the default directory
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .loginDefaultDirectory(
+     withUsername: "support@auth0.com",
+     password: "a secret password")
+     ```
+     
+     You can also specify audience and scope
+     
+     ```
+     Auth0
+     .authentication(clientId: clientId, domain: "samples.auth0.com")
+     .loginDefaultDirectory(
+     withUsername: "support@auth0.com",
+     password: "a secret password",
+     audience: "https://myapi.com/api",
+     scope: "openid profile")
+     ```
+     
+     - parameter username:    username or email used of the user to authenticate
+     - parameter password:    password of the user
+     - parameter audience:    API Identifier that the client is requesting access to.
+     - parameter scope:       scope value requested when authenticating the user.
+     - parameter parameters:  additional parameters that are optionally sent with the authentication request
+     
+     - important: This only works if you have the OAuth 2.0 API Authorization flag on
+     - returns: authentication request that will yield Auth0 User Credentials
+     */
+    func loginDefaultDirectory(withUsername username: String, password: String, audience: String? = nil, scope: String? = nil, parameters: [String: Any]? = nil) -> Request<Credentials, AuthenticationError> {
+        return self.loginDefaultDirectory(withUsername: username, password: password, audience: audience, scope: scope, parameters: parameters)
+    }
+
+    /**
      Creates a user in a Database connection
 
      ```
@@ -632,11 +704,27 @@ public extension Authentication {
      - parameter password:          password for the new user
      - parameter connection:        name where the user will be created (Database connection)
      - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
+     - parameter rootAttributes:    root attributes that will be added to the newly created user. See https://auth0.com/docs/api/authentication#signup for supported attributes. Will not overwrite existing parameters.
 
      - returns: request that will yield a created database user (just email, username and email verified flag)
      */
+    func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil, rootAttributes: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
+        return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: rootAttributes)
+    }
+
+    /**
+     Creates a user in a Database connection
+     
+     - parameter email:             email of the user to create
+     - parameter username:          username of the user if the connection requires username. By default is 'nil'
+     - parameter password:          password for the new user
+     - parameter connection:        name where the user will be created (Database connection)
+     - parameter userMetadata:      additional userMetadata parameters that will be added to the newly created user.
+    
+     - returns: request that will yield a created database user (just email, username and email verified flag)
+     */
     func createUser(email: String, username: String? = nil, password: String, connection: String, userMetadata: [String: Any]? = nil) -> Request<DatabaseUser, AuthenticationError> {
-        return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata)
+        return self.createUser(email: email, username: username, password: password, connection: connection, userMetadata: userMetadata, rootAttributes: nil)
     }
 
     /**
@@ -806,5 +894,57 @@ public extension Authentication {
      */
     func renew(withRefreshToken refreshToken: String, scope: String? = nil) -> Request<Credentials, AuthenticationError> {
         return self.renew(withRefreshToken: refreshToken, scope: scope)
+    }
+
+    /**
+    Authenticate a user with their Sign In With Apple authorization code.
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .tokenExchange(withAppleAuthorizationCode: authCode)
+       .start { print($0) }
+    ```
+
+    and if you need to specify a scope or add additional parameters
+
+    ```
+    Auth0
+       .authentication(clientId: clientId, domain: "samples.auth0.com")
+       .tokenExchange(withAppleAuthorizationCode: authCode, scope: "openid profile offline_access", audience: "https://myapi.com/api, fullName: credentials.fullName)
+       .start { print($0) }
+    ```
+
+    - parameter authCode: Authorization Code retrieved from Apple Authorization
+    - parameter scope: requested scope value when authenticating the user. By default is 'openid profile offline_access'
+    - parameter audience: API Identifier that the client is requesting access to
+    - parameter fullName: The full name property returned with the Apple ID Credentials
+
+    - returns: a request that will yield Auth0 user's credentials
+    */
+    func tokenExchange(withAppleAuthorizationCode authCode: String, scope: String? = nil, audience: String? = nil, fullName: PersonNameComponents? = nil) -> Request<Credentials, AuthenticationError> {
+        var parameters: [String: String] =
+            [ "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+              "subject_token": authCode,
+              "subject_token_type": "http://auth0.com/oauth/token-type/apple-authz-code",
+              "scope": scope ?? "openid profile offline_access" ]
+        if let fullName = fullName {
+            let name = [
+                "firstName": fullName.givenName,
+                "lastName": fullName.familyName
+            ].filter { $0.value != nil }.mapValues { $0! }
+            if !name.isEmpty, let jsonData = try? String(
+                    data: JSONSerialization.data(
+                        withJSONObject: [
+                            "name": name
+                        ],
+                        options: []),
+                    encoding: String.Encoding.utf8
+            ) {
+                parameters["user_profile"] = jsonData
+            }
+        }
+        parameters["audience"] = audience
+        return self.tokenExchange(withParameters: parameters)
     }
 }

--- a/FiveCalls/Pods/Auth0/Auth0/CredentialsManager.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/CredentialsManager.swift
@@ -29,7 +29,7 @@ import LocalAuthentication
 /// Credentials management utility
 public struct CredentialsManager {
 
-    private let storage = A0SimpleKeychain()
+    private let storage: A0SimpleKeychain
     private let storeKey: String
     private let authentication: Authentication
     #if os(iOS)
@@ -41,9 +41,11 @@ public struct CredentialsManager {
     /// - Parameters:
     ///   - authentication: Auth0 authentication instance
     ///   - storeKey: Key used to store user credentials in the keychain, defaults to "credentials"
-    public init(authentication: Authentication, storeKey: String = "credentials") {
+    ///   - storage: The A0SimpleKeychain instance used to manage credentials storage. Defaults to a standard A0SimpleKeychain instance
+    public init(authentication: Authentication, storeKey: String = "credentials", storage: A0SimpleKeychain = A0SimpleKeychain()) {
         self.storeKey = storeKey
         self.authentication = authentication
+        self.storage = storage
     }
 
     /// Enable Touch ID Authentication for additional security during credentials retrieval.
@@ -86,6 +88,34 @@ public struct CredentialsManager {
         return self.storage.deleteEntry(forKey: storeKey)
     }
 
+    /// Calls the revoke token endpoint to revoke the refresh token and, if successful, the credentials are cleared. Otherwise,
+    /// the credentials are not cleared and an error is raised through the callback.
+    ///
+    /// If no refresh token is available the endpoint is not called, the credentials are cleared, and the callback is invoked without an error.
+    ///
+    /// - Parameter callback: callback with an error if the refresh token could not be revoked
+    public func revoke(_ callback: @escaping (CredentialsManagerError?) -> Void) {
+        guard
+            let data = self.storage.data(forKey: self.storeKey),
+            let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials,
+            let refreshToken = credentials.refreshToken else {
+                _ = self.clear()
+                return callback(nil)
+        }
+
+        self.authentication
+            .revoke(refreshToken: refreshToken)
+            .start { result in
+                switch result {
+                case .failure(let error):
+                    callback(CredentialsManagerError.revokeFailed(error))
+                case .success:
+                    _ = self.clear()
+                    callback(nil)
+                }
+            }
+    }
+
     /// Checks if a non-expired set of credentials are stored
     ///
     /// - Returns: if there are valid and non-expired credentials stored
@@ -93,10 +123,9 @@ public struct CredentialsManager {
         guard
             let data = self.storage.data(forKey: self.storeKey),
             let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials,
-            credentials.accessToken != nil,
-            let expiresIn = credentials.expiresIn
+            credentials.accessToken != nil
             else { return false }
-        return expiresIn > Date() || credentials.refreshToken != nil
+        return !self.hasExpired(credentials) || credentials.refreshToken != nil
     }
 
     /// Retrieve credentials from keychain and yield new credentials using refreshToken if accessToken has expired
@@ -143,8 +172,8 @@ public struct CredentialsManager {
             let data = self.storage.data(forKey: self.storeKey),
             let credentials = NSKeyedUnarchiver.unarchiveObject(with: data) as? Credentials
             else { return callback(.noCredentials, nil) }
-        guard let expiresIn = credentials.expiresIn else { return callback(.noCredentials, nil) }
-        guard expiresIn < Date() else { return callback(nil, credentials) }
+        guard credentials.expiresIn != nil else { return callback(.noCredentials, nil) }
+        guard self.hasExpired(credentials) else { return callback(nil, credentials) }
         guard let refreshToken = credentials.refreshToken else { return callback(.noRefreshToken, nil) }
 
         self.authentication.renew(withRefreshToken: refreshToken, scope: scope).start {
@@ -163,4 +192,41 @@ public struct CredentialsManager {
             }
         }
     }
+
+    func hasExpired(_ credentials: Credentials) -> Bool {
+
+        if let expiresIn = credentials.expiresIn {
+            if expiresIn < Date() { return true }
+        }
+
+        if let token = credentials.idToken,
+            let tokenDecoded = decode(jwt: token),
+            let exp = tokenDecoded["exp"] as? Double {
+            if Date(timeIntervalSince1970: exp) < Date() { return true }
+        }
+
+        return false
+    }
+}
+
+func decode(jwt: String) -> [String: Any]? {
+    let parts = jwt.components(separatedBy: ".")
+    guard parts.count == 3 else { return nil }
+    var base64 = parts[1]
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+    let requiredLength = 4 * ceil(length / 4.0)
+    let paddingLength = requiredLength - length
+    if paddingLength > 0 {
+        let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+        base64 += padding
+    }
+
+    guard
+        let bodyData = Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+        else { return nil }
+
+    let json = try? JSONSerialization.jsonObject(with: bodyData, options: [])
+    return json as? [String: Any]
 }

--- a/FiveCalls/Pods/Auth0/Auth0/CredentialsManagerError.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/CredentialsManagerError.swift
@@ -27,4 +27,5 @@ public enum CredentialsManagerError: Error {
     case noRefreshToken
     case failedRefresh(Error)
     case touchFailed(Error)
+    case revokeFailed(Error)
 }

--- a/FiveCalls/Pods/Auth0/Auth0/Profile.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/Profile.swift
@@ -28,7 +28,7 @@ import Foundation
  - seeAlso: [Normalized User Profile](https://auth0.com/docs/user-profile/normalized)
  */
 @objc(A0Profile)
-public class Profile: NSObject, JSONObjectPayload {
+@objcMembers public class Profile: NSObject, JSONObjectPayload {
 
     public let id: String
     public let name: String

--- a/FiveCalls/Pods/Auth0/Auth0/SafariAuthenticationSession.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/SafariAuthenticationSession.swift
@@ -30,55 +30,118 @@ import AuthenticationServices
 @available(iOS 11.0, *)
 class SafariAuthenticationSession: AuthSession {
 
-    private var authSession: NSObject?
+    private enum AuthenticationSession {
+
+        @available(iOS 12.0, *)
+        case authenticationServices(ASWebAuthenticationSession)
+
+        case safariServices(SFAuthenticationSession)
+
+        @available(iOS 12.0, *)
+        init(_ session: ASWebAuthenticationSession) {
+            self = .authenticationServices(session)
+        }
+
+        init(_ session: SFAuthenticationSession) {
+            self = .safariServices(session)
+        }
+
+        func start() -> Bool {
+            switch self {
+            case .authenticationServices(let session):
+                return session.start()
+            case .safariServices(let session):
+                return session.start()
+            }
+        }
+
+        func cancel() {
+            switch self {
+            case .authenticationServices(let session):
+                return session.cancel()
+            case .safariServices(let session):
+                return session.cancel()
+            }
+        }
+    }
+
+    private var authSession: AuthenticationSession?
 
     init(authorizeURL: URL, redirectURL: URL, state: String? = nil, handler: OAuth2Grant, finish: @escaping FinishSession, logger: Logger?) {
         super.init(redirectURL: redirectURL, state: state, handler: handler, finish: finish, logger: logger)
         #if canImport(AuthenticationServices)
         if #available(iOS 12.0, *) {
-            let authSession = ASWebAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
+            let webAuthenticationSession = ASWebAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
                 guard $1 == nil, let callbackURL = $0 else {
-                    if case ASWebAuthenticationSessionError.canceledLogin = $1! {
+                    let authError = $1 ?? WebAuthError.unknownError
+                    if case ASWebAuthenticationSessionError.canceledLogin = authError {
                         self.finish(.failure(error: WebAuthError.userCancelled))
                     } else {
-                        self.finish(.failure(error: $1!))
+                        self.finish(.failure(error: authError))
                     }
                     return TransactionStore.shared.clear()
                 }
                 _ = TransactionStore.shared.resume(callbackURL, options: [:])
-                }
-            self.authSession = authSession
-            authSession.start()
+            }
+            #if swift(>=5.1)
+            if #available(iOS 13.0, *) {
+                webAuthenticationSession.presentationContextProvider = self
+            }
+            #endif
+            authSession = .init(webAuthenticationSession)
         } else {
-            let authSession = SFAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
+            authSession = .init(SFAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
                 guard $1 == nil, let callbackURL = $0 else {
-                    if case SFAuthenticationError.canceledLogin = $1! {
+                    let authError = $1 ?? WebAuthError.unknownError
+                    if case SFAuthenticationError.canceledLogin = authError {
                         self.finish(.failure(error: WebAuthError.userCancelled))
                     } else {
-                        self.finish(.failure(error: $1!))
+                        self.finish(.failure(error: authError))
                     }
                     return TransactionStore.shared.clear()
                 }
                 _ = TransactionStore.shared.resume(callbackURL, options: [:])
-                }
-            self.authSession = authSession
-            authSession.start()
+            })
         }
         #else
-        let authSession = SFAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
+        authSession = .init(SFAuthenticationSession(url: authorizeURL, callbackURLScheme: self.redirectURL.absoluteString) { [unowned self] in
             guard $1 == nil, let callbackURL = $0 else {
-                if case SFAuthenticationError.canceledLogin = $1! {
+                let authError = $1 ?? WebAuthError.unknownError
+                if case SFAuthenticationError.canceledLogin = authError {
                     self.finish(.failure(error: WebAuthError.userCancelled))
                 } else {
-                    self.finish(.failure(error: $1!))
+                    self.finish(.failure(error: authError))
                 }
                 return TransactionStore.shared.clear()
             }
             _ = TransactionStore.shared.resume(callbackURL, options: [:])
-        }
-        self.authSession = authSession
-        authSession.start()
+        })
         #endif
+        _ = authSession?.start()
+    }
+
+    override func resume(_ url: URL, options: [A0URLOptionsKey: Any]) -> Bool {
+        if super.resume(url, options: options) {
+            authSession?.cancel()
+            authSession = nil
+            return true
+        }
+        return false
+    }
+
+    override func cancel() {
+        super.cancel()
+        authSession?.cancel()
+        authSession = nil
     }
 }
+
+#if swift(>=5.1)
+@available(iOS 13.0, *)
+extension SafariAuthenticationSession: ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return UIApplication.shared.keyWindow ?? ASPresentationAnchor()
+    }
+}
+#endif
 #endif

--- a/FiveCalls/Pods/Auth0/Auth0/Telemetry.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/Telemetry.swift
@@ -100,7 +100,9 @@ public struct Telemetry {
     }
 
     static func swiftVersion() -> String {
-        #if swift(>=4.0)
+        #if swift(>=5.0)
+        return "5.x"
+        #elseif swift(>=4.0)
         return "4.x"
         #elseif swift(>=3.0)
         return "3.x"

--- a/FiveCalls/Pods/Auth0/Auth0/UserInfo.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/UserInfo.swift
@@ -25,7 +25,7 @@ import Foundation
 /// OIDC Standard Claims user information
 /// - note: [Claims](https://auth0.com/docs/protocols/oidc#claims)
 @objc(A0UserInfo)
-public class UserInfo: NSObject, JSONObjectPayload {
+@objcMembers public class UserInfo: NSObject, JSONObjectPayload {
 
     public static let publicClaims = ["sub", "name", "given_name", "family_name", "middle_name", "nickname", "preferred_username", "profile", "picture", "website", "email", "email_verified", "gender", "birthdate", "zoneinfo", "locale", "phone_number", "phone_number_verified", "address", "updated_at"]
 

--- a/FiveCalls/Pods/Auth0/Auth0/WebAuth.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/WebAuth.swift
@@ -21,6 +21,9 @@
 // THE SOFTWARE.
 
 import UIKit
+#if canImport(AuthenticationServices)
+import AuthenticationServices
+#endif
 
 #if swift(>=4.2)
 public typealias A0URLOptionsKey = UIApplication.OpenURLOptionsKey
@@ -185,10 +188,11 @@ public protocol WebAuth: Trackable, Loggable {
      Use `SFSafariViewController` instead of `SFAuthenticationSession` for WebAuth
      in iOS 11.0+.
 
+     - Parameter style: modal presentation style
      - returns: the same WebAuth instance to allow method chaining
      */
     @available(iOS 11, *)
-    func useLegacyAuthentication() -> Self
+    func useLegacyAuthentication(withStyle style: UIModalPresentationStyle) -> Self
 
     /**
      Starts the WebAuth flow by modally presenting a ViewController in the top-most controller.
@@ -242,4 +246,19 @@ public protocol WebAuth: Trackable, Loggable {
      - parameter callback: callback called with bool outcome of the call
      */
     func clearSession(federated: Bool, callback: @escaping (Bool) -> Void)
+}
+
+public extension WebAuth {
+
+    /**
+     Use `SFSafariViewController` instead of `SFAuthenticationSession` for WebAuth
+     in iOS 11.0+.
+     Defaults to .fullScreen modal presentation style.
+     
+     - returns: the same WebAuth instance to allow method chaining
+     */
+    @available(iOS 11, *)
+    func useLegacyAuthentication() -> Self {
+        return useLegacyAuthentication(withStyle: .fullScreen)
+    }
 }

--- a/FiveCalls/Pods/Auth0/Auth0/WebAuthError.swift
+++ b/FiveCalls/Pods/Auth0/Auth0/WebAuthError.swift
@@ -42,6 +42,7 @@ public enum WebAuthError: CustomNSError {
     case missingResponseParam(String)
     case invalidIdTokenNonce
     case missingAccessToken
+    case unknownError
 
     static let genericFoundationCode = 1
     static let cancelledFoundationCode = 0

--- a/FiveCalls/Pods/Auth0/README.md
+++ b/FiveCalls/Pods/Auth0/README.md
@@ -13,8 +13,11 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 ## Requirements
 
 - iOS 9+ / macOS 10.11+ / tvOS 9.0+ / watchOS 2.0+
-- Xcode 10.x
+- Xcode 10.x/11.x
 - Swift 4.x/5.x
+
+## Important Notice
+Behaviour changes in iOS 13 related to Web Authentication require that developers using Xcode 11 with this library **must** compile using Swift 5.x. This *should* be the default setting applied when updating, unless it has been manually set. However, we recommend checking that this value is set correctly.
 
 ## Installation
 
@@ -23,7 +26,7 @@ Swift toolkit that lets you communicate efficiently with many of the [Auth0 API]
 If you are using Carthage, add the following lines to your `Cartfile`:
 
 ```ruby
-github "auth0/Auth0.swift" ~> 1.15
+github "auth0/Auth0.swift" ~> 1.19
 ```
 
 Then run `carthage bootstrap`.
@@ -36,7 +39,7 @@ If you are using [Cocoapods](https://cocoapods.org/), add these lines to your `P
 
 ```ruby
 use_frameworks!
-pod 'Auth0', '~> 1.15'
+pod 'Auth0', '~> 1.19'
 ```
 
 Then run `pod install`.
@@ -44,9 +47,7 @@ Then run `pod install`.
 > For further reference on Cocoapods, check [their official documentation](http://guides.cocoapods.org/using/getting-started.html).
 
 > ### Upgrade Notes
-> If you are using the [clearSession](https://github.com/auth0/Auth0.swift/blob/master/Auth0/WebAuth.swift#L235) method in iOS 11+, you will need to ensure that the **Callback URL** has been added to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
-
-
+> If you are using the [clearSession](https://github.com/auth0/Auth0.swift/blob/master/Auth0/WebAuth.swift#L248) method in iOS 11+, you will need to ensure that the **Callback URL** has been added to the **Allowed Logout URLs** section of your application in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/).
 
 ## Getting started
 
@@ -85,7 +86,7 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpe
 
 In order to use Auth0 you need to provide your Auth0 **ClientId** and **Domain**.
 
-> Auth0 ClientId & Domain can be found in your [Auth0 Dashboard](https://manage.auth0.com)
+> Auth0 ClientId & Domain can be found in your [Auth0 Dashboard](https://manage.auth0.com/#/applications/)
 
 #### Adding Auth0 Credentials
 
@@ -97,16 +98,16 @@ In your application bundle add a `plist` file named `Auth0.plist` with the follo
 <plist version="1.0">
 <dict>
   <key>ClientId</key>
-  <string>{YOUR_CLIENT_ID}</string>
+  <string>YOUR_AUTH0_CLIENT_ID</string>
   <key>Domain</key>
-  <string>{YOUR_DOMAIN}</string>
+  <string>YOUR_AUTH0_DOMAIN</string>
 </dict>
 </plist>
 ```
 
 #### Configure Callback URLs (iOS Only)
 
-Callback URLs are the URLs that Auth0 invokes after the authentication process. Auth0 routes your application back to this URL and appends additional parameters to it, including a token. Since callback URLs can be manipulated, you will need to add your application's URL to your client's **Allowed Callback URLs** for security. This will enable Auth0 to recognize these URLs as valid. If omitted, authentication will not be successful.
+Callback URLs are the URLs that Auth0 invokes after the authentication process. Auth0 routes your application back to this URL and appends additional parameters to it, including a token. Since callback URLs can be manipulated, you will need to add your callback URL to the **Allowed Callback URLs** field in the [Auth0 Dashboard](https://manage.auth0.com/#/applications/). This will enable Auth0 to recognize these URLs as valid. If omitted, authentication will not be successful.
 
 In your application's `Info.plist` file, register your iOS Bundle Identifer as a custom scheme:
 
@@ -122,7 +123,7 @@ In your application's `Info.plist` file, register your iOS Bundle Identifer as a
         <string>auth0</string>
         <key>CFBundleURLSchemes</key>
         <array>
-            <string>$(YOUR_BUNDLE_IDENTIFIER)</string>
+            <string>YOUR_BUNDLE_IDENTIFIER</string>
         </array>
     </dict>
 </array>
@@ -130,13 +131,13 @@ In your application's `Info.plist` file, register your iOS Bundle Identifer as a
 
 > If your `Info.plist` is not shown in this format, you can **Right Click** on `Info.plist` in Xcode and then select **Open As / Source Code**.
 
-Finally, go to your [Auth0 Dashboard](${manage_url}/#/applications/${account.clientId}/settings) and make sure that **Allowed Callback URLs** contains the following entry:
+Finally, go to your [Auth0 Dashboard](https://manage.auth0.com) and make sure that your application's **Allowed Callback URLs** field contains the following entry:
 
 ```text
-{YOUR_BUNDLE_IDENTIFIER}://${YOUR_AUTH0_DOMAIN}/ios/{YOUR_BUNDLE_IDENTIFIER}/callback
+YOUR_BUNDLE_IDENTIFIER://YOUR_AUTH0_DOMAIN/ios/YOUR_BUNDLE_IDENTIFIER/callback
 ```
 
-e.g. If your bundle identifier was `com.company.myapp` and your domain was `company.auth0.com` then this value would be
+e.g. If your bundle identifier was `com.company.myapp` and your Auth0 domain was `company.auth0.com` then this value would be
 
 ```text
 com.company.myapp://company.auth0.com/ios/com.company.myapp/callback
@@ -213,6 +214,26 @@ credentialsManager.credentials { error, credentials in
 }
 ```
 
+#### Clearing credentials and revoking refresh tokens
+
+Credentials can be cleared by using the `clear` function, which clears credentials from the keychain:
+
+```swift
+let didClear = credentialsManager.clear()
+```
+
+In addition, credentials can be cleared and the refresh token revoked using a single call to `revoke`. This function will attempt to revoke the current refresh token stored by the credential manager and then clear credentials from the keychain. If revoking the token results in an error, then the credentials are not cleared:
+
+```swift
+credentialsManager.revoke { error in
+    guard error == nil else {
+        return print("Failed to revoke refresh token: \(error)")
+    }
+    
+    print("Success")
+}
+```
+
 #### Biometric authentication
 
 You can enable an additional level of user authentication before retrieving credentials using the biometric authentication supported by your device e.g. Face ID or Touch ID.
@@ -220,6 +241,26 @@ You can enable an additional level of user authentication before retrieving cred
 ```swift
 credentialsManager.enableBiometrics(withTitle: "Touch to Login")
 ```
+
+### Sign in With Apple
+
+If you've added [the Sign In with Apple Flow to Your App](https://developer.apple.com/documentation/authenticationservices/adding_the_sign_in_with_apple_flow_to_your_app) you can use the string value from the  `authorizationCode` property obtained after a successful Apple authentication to perform a token exchange for Auth0 tokens.
+
+```swift
+Auth0
+    .authentication()
+    .tokenExchange(withAppleAuthorizationCode: authCode)
+    .start { result in
+        switch result {
+        case .success(let credentials):
+            print("Obtained credentials: \(credentials)")
+        case .failure(let error):
+            print("Failed with \(error)")
+        }
+}
+```
+
+Find out more about [Setting up Sign in with Apple](https://auth0.com/docs/connections/apple-setup) with Auth0.
 
 ### Authentication API (iOS / macOS / tvOS)
 

--- a/FiveCalls/Pods/Manifest.lock
+++ b/FiveCalls/Pods/Manifest.lock
@@ -7,7 +7,7 @@ PODS:
   - AppCenter/Core (2.0.1)
   - AppCenter/Crashes (2.0.1):
     - AppCenter/Core
-  - Auth0 (1.15.0):
+  - Auth0 (1.19.3):
     - SimpleKeychain
   - CPDAcknowledgements (1.0.0)
   - Down (0.5.2)
@@ -30,7 +30,7 @@ PODS:
 
 DEPENDENCIES:
   - AppCenter
-  - Auth0 (~> 1.15)
+  - Auth0 (~> 1.17)
   - CPDAcknowledgements (from `https://github.com/CocoaPods/CPDAcknowledgements.git`)
   - Down
   - DZNEmptyDataSet (from `https://github.com/subdigital/DZNEmptyDataSet`)
@@ -42,13 +42,14 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AppCenter
-    - Auth0
     - Down
     - Kingfisher
     - OneSignal
     - PromiseKit
     - R.swift
     - R.swift.Library
+  trunk:
+    - Auth0
     - SimpleKeychain
 
 EXTERNAL SOURCES:
@@ -67,7 +68,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   AppCenter: 6a5ff2fd007b53431259fdd74f91eb3d0dfea3d1
-  Auth0: b741c805711a80eb698fce55d354cc32e0784dce
+  Auth0: 195ea089de471c72bf95eb5320ff86c224debf3c
   CPDAcknowledgements: 6e15e71849ba4ad5e8a17a0bb9d20938ad23bac8
   Down: 587371ad58002b06023d9c602519216862c3acbc
   DZNEmptyDataSet: b94434220f87d9dda46660eb4f07a424778e93b4
@@ -78,6 +79,6 @@ SPEC CHECKSUMS:
   R.swift.Library: cfe85d569d9bae6cb262922db130e7c3a7a5fad1
   SimpleKeychain: 3be49072fd2d82de8fa83d847ef1e548622f8fc5
 
-PODFILE CHECKSUM: 5d8c0bcc03b1bb067cdf57dde0fa26882153fd76
+PODFILE CHECKSUM: 4cb8dc1b7061d9d6ccbfc7db606299667bda4c68
 
 COCOAPODS: 1.8.4

--- a/FiveCalls/Pods/Pods-FiveCalls-metadata.plist
+++ b/FiveCalls/Pods/Pods-FiveCalls-metadata.plist
@@ -118,7 +118,7 @@ SOFTWARE.
 			<key>summary</key>
 			<string>Swift toolkit for Auth0 API</string>
 			<key>version</key>
-			<string>1.15.0</string>
+			<string>1.19.3</string>
 		</dict>
 		<dict>
 			<key>authors</key>

--- a/FiveCalls/Pods/Pods.xcodeproj/project.pbxproj
+++ b/FiveCalls/Pods/Pods.xcodeproj/project.pbxproj
@@ -2401,37 +2401,6 @@
 			};
 			name = Debug;
 		};
-		0A335930E081DFF3A24B8685F6782FC6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F317AAA9CBD15B9F5A892E2A89850B0A /* Auth0.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Auth0/Auth0-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Auth0/Auth0-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Auth0/Auth0.modulemap";
-				PRODUCT_MODULE_NAME = Auth0;
-				PRODUCT_NAME = Auth0;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		1F2E81757D76E43042739BC5AEFFE429 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2505,6 +2474,37 @@
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
+		};
+		3550CF976CA89EB5FA3567578A62C523 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F317AAA9CBD15B9F5A892E2A89850B0A /* Auth0.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Auth0/Auth0-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Auth0/Auth0-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Auth0/Auth0.modulemap";
+				PRODUCT_MODULE_NAME = Auth0;
+				PRODUCT_NAME = Auth0;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		398726D960DCA44CB9C7D5866A06AEDB /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2943,6 +2943,38 @@
 			};
 			name = Release;
 		};
+		9AE8A352E5A4ACC85BD4336E163D8008 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F317AAA9CBD15B9F5A892E2A89850B0A /* Auth0.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Auth0/Auth0-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Auth0/Auth0-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Auth0/Auth0.modulemap";
+				PRODUCT_MODULE_NAME = Auth0;
+				PRODUCT_NAME = Auth0;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		A74E35A75E2EE20767E92AAF4580D480 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C04F8FA83A1E11F32B0EF91047B2235B /* Pods-FiveCalls.release.xcconfig */;
@@ -2971,38 +3003,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		AE12E186CFE15F6F70A72E90E615E2C0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F317AAA9CBD15B9F5A892E2A89850B0A /* Auth0.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Auth0/Auth0-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Auth0/Auth0-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Auth0/Auth0.modulemap";
-				PRODUCT_MODULE_NAME = Auth0;
-				PRODUCT_NAME = Auth0;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -3364,8 +3364,8 @@
 		6E3DA00F435DE65964EDC87468F70658 /* Build configuration list for PBXNativeTarget "Auth0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0A335930E081DFF3A24B8685F6782FC6 /* Debug */,
-				AE12E186CFE15F6F70A72E90E615E2C0 /* Release */,
+				3550CF976CA89EB5FA3567578A62C523 /* Debug */,
+				9AE8A352E5A4ACC85BD4336E163D8008 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/FiveCalls/Pods/Target Support Files/Auth0/Auth0-Info.plist
+++ b/FiveCalls/Pods/Target Support Files/Auth0/Auth0-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.15.0</string>
+  <string>1.19.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/FiveCalls/Pods/Target Support Files/Auth0/Info.plist
+++ b/FiveCalls/Pods/Target Support Files/Auth0/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.12.0</string>
+  <string>1.15.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/FiveCalls/Pods/Target Support Files/R.swift.Library/Info.plist
+++ b/FiveCalls/Pods/Target Support Files/R.swift.Library/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>4.0.0</string>
+  <string>5.0.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/FiveCalls/Pods/Target Support Files/SimpleKeychain/Info.plist
+++ b/FiveCalls/Pods/Target Support Files/SimpleKeychain/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.8.1</string>
+  <string>0.9.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
It's possible that #233 was caused by network races - as the report is going back, we'll see if unreported stats need to be filled in the `viewDidLoad` for the main issues screen. Instead of reporting them immediately, let's only report backfilled stats that are more than a few minutes old.

Additionally, we needed to update auth0 for iOS 13, otherwise it would break login.