### PR TITLE
Adapt contact log search to check for old contact ids too

### DIFF
--- a/FiveCalls/FiveCalls/AnalyticsManager.swift
+++ b/FiveCalls/FiveCalls/AnalyticsManager.swift
@@ -33,6 +33,6 @@ class AnalyticsManager {
     }
     
     func trackError(error: Error) {
-        // MSAnalytics...
+        MSAnalytics.trackEvent("Error", withProperties: ["message": error.localizedDescription])
     }
 }

--- a/FiveCalls/FiveCalls/ContactLog.swift
+++ b/FiveCalls/FiveCalls/ContactLog.swift
@@ -122,7 +122,7 @@ extension ContactLogs {
         let appSupportDir = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!
         let files = try? FileManager.default.contentsOfDirectory(atPath: URL(fileURLWithPath: appSupportDir).appendingPathComponent(pantryDirName).path)
 
-        print("directory is \(files)")
+        print("directory is \(String(describing: files))")
     }
     
     static func load() -> ContactLogs {

--- a/FiveCalls/FiveCalls/ContactLog.swift
+++ b/FiveCalls/FiveCalls/ContactLog.swift
@@ -41,12 +41,12 @@ struct ContactLogs {
         NotificationCenter.default.post(name: .callMade, object: log)
     }
         
-    func methodOfContact(to contactId: String, forIssue issueId: Int64) -> String? {
-        return all.filter({$0.contactId == contactId && $0.issueId == String(issueId)}).last?.outcome
+    func methodOfContact(to contactId: String, forIssue issue: Issue) -> String? {
+        return all.filter({$0.contactId == contactId && ($0.issueId == String(issue.id) || $0.issueId == issue.meta)}).last?.outcome
     }
 
-    func hasContacted(contactId: String, forIssue issueId: Int64) -> Bool {
-        guard let method = methodOfContact(to: contactId, forIssue: issueId) else {
+    func hasContacted(contact: Contact, forIssue issue: Issue) -> Bool {
+        guard let method = methodOfContact(to: contact.id, forIssue: issue) else {
             return false
         }
         
@@ -58,23 +58,13 @@ struct ContactLogs {
             return false
         }        
     }
-    
-    func hasCompleted(issue: Int64, allContacts: [Contact]) -> Bool {
-        if (allContacts.count == 0) {
-            return false
-        }
-        for contact in allContacts {
-            if !hasContacted(contactId: contact.id, forIssue: issue) {
-                return false
-            }
-        }
-        return true
-    }
-    
+
     // Gets a list of unreported contacts
     func unreported() -> [ContactLog] {
         return all.filter({$0.reported == false})
     }
+
+    // MARK: mutating functions
     
     mutating func markAllReported(_ logs: [ContactLog]) {
         logs.forEach { self.markReported($0) }
@@ -89,6 +79,8 @@ struct ContactLogs {
             all.append(ContactLog(issueId: log.issueId, contactId: log.contactId, phone: log.phone, outcome: log.outcome, date: log.date, reported: true))
         }
     }
+
+    // MARK: the file path for locally saved contact logs that was inherited from pantry
     
     static private var filePath: URL {
         let pantryDirName = "com.thatthinginswift.pantry"
@@ -105,7 +97,7 @@ struct ContactLogs {
         try? FileManager.default.createDirectory(at: targetPath, withIntermediateDirectories: true)
 
         return targetPath.appendingPathComponent(ContactLogs.persistenceKey, isDirectory: false)
-    }    
+    }
 }
 
 extension ContactLogs {
@@ -122,13 +114,28 @@ extension ContactLogs {
             }
         }
     }
+
+    static func debugContactLogs() {
+        print("file should be at \(ContactLogs.filePath)")
+
+        let pantryDirName = "com.thatthinginswift.pantry"
+        let appSupportDir = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!
+        let files = try? FileManager.default.contentsOfDirectory(atPath: URL(fileURLWithPath: appSupportDir).appendingPathComponent(pantryDirName).path)
+
+        print("directory is \(files)")
+    }
     
     static func load() -> ContactLogs {
+//        ContactLogs.debugContactLogs()
+
         if let fileData = try? Data(contentsOf: ContactLogs.filePath) {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
             if let wrapper = try? decoder.decode(LegacyPantryWrapper.self, from: fileData) {
                 return ContactLogs(logs: wrapper.storage)
+            } else {
+                print("couldn't decode wrapper")
+                AnalyticsManager.shared.trackError(error: ContactLogError.CantDecodeWrapper)
             }
         }
         
@@ -139,4 +146,8 @@ extension ContactLogs {
     static func removeData() {
         try? FileManager.default.removeItem(at: ContactLogs.filePath)
     }
+}
+
+enum ContactLogError: Error {
+    case CantDecodeWrapper
 }

--- a/FiveCalls/FiveCalls/Info.plist
+++ b/FiveCalls/FiveCalls/Info.plist
@@ -84,5 +84,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/FiveCalls/FiveCalls/Issue.swift
+++ b/FiveCalls/FiveCalls/Issue.swift
@@ -11,6 +11,7 @@ import Rswift
 
 struct Issue : Decodable {
     let id: Int64
+    let meta: String
     let name: String
     let slug: String
     let reason: String

--- a/FiveCalls/FiveCalls/IssueDetailViewController.swift
+++ b/FiveCalls/FiveCalls/IssueDetailViewController.swift
@@ -204,7 +204,7 @@ extension IssueDetailViewController : UITableViewDataSource {
                 } else {
                     cell.avatarImageView.image = UIImage(named: "icon-office")
                 }
-                if let hasContacted = logs?.hasContacted(contactId: contact.id, forIssue: issue.id) {
+                if let hasContacted = logs?.hasContacted(contact: contact, forIssue: issue) {
                     cell.hasContacted = hasContacted
                 }
                 return cell

--- a/FiveCalls/FiveCalls/IssuesViewController.swift
+++ b/FiveCalls/FiveCalls/IssuesViewController.swift
@@ -256,12 +256,13 @@ class IssuesViewController : UITableViewController {
 
         var numContactsContacted = 0
         for contact in issueContacts {
-            if let contacted = logs?.hasContacted(contactId: contact.id, forIssue: issue.id) {
+            if let contacted = logs?.hasContacted(contact: contact, forIssue: issue) {
                 if contacted {
                     numContactsContacted = numContactsContacted + 1
                 }
             }
         }
+
 //        // avoid NaN problem if there are no contacts
         let progress = issueContacts.count < 1 ? 0.0 : Double(numContactsContacted) / Double(issueContacts.count)
         cell.progressView.progress = progress


### PR DESCRIPTION
We use numbers for unique issue IDs in the new API, but the old IDs are still around in the `meta` field on the issues. Let's check for both right now and in the future we can remove the meta once current issues fall off the list.

Fixes #280 