### PR TITLE
If a contactmanager doesn't exist, create one

### DIFF
--- a/FiveCalls/FiveCalls/DonateCell.swift
+++ b/FiveCalls/FiveCalls/DonateCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class DonateCell: UITableViewCell {
-    let donateURL = URL(string: "https://secure.actblue.com/donate/5calls-donate")!
+    let donateURL = URL(string: "https://secure.actblue.com/donate/5calls-donate?refcode=ios")!
     @IBOutlet var donateButton: UIButton!
     
     func configure() {

--- a/FiveCalls/FiveCalls/IssueDetailViewController.swift
+++ b/FiveCalls/FiveCalls/IssueDetailViewController.swift
@@ -37,6 +37,12 @@ class IssueDetailViewController : UIViewController, IssueShareable {
 
     private func loadContacts() {
         print("Loading contacts for: \(issue.contactAreas)")
+
+        // we pass this contact manager around and there's some case where it doesn't make it here,
+        // create it here if it doesnt exist, with the addition of some latency in fetchContacts for getting contacts again
+        if contactsManager == nil {
+            contactsManager = ContactsManager()
+        }
         
         contactsManager.fetchContacts(location: UserLocation.current) { result in
             switch result {


### PR DESCRIPTION
Trying to fix this crash, where contactmanager is nil:

https://appcenter.ms/orgs/5-Calls/apps/5-Calls-iOS/crashes/errors/769878387u/overview