### PR TITLE
Remove the copy warning

### DIFF
--- a/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="IFq-NR-IrM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="IFq-NR-IrM">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -473,7 +473,7 @@
             </objects>
             <point key="canvasLocation" x="2732" y="-1077"/>
         </scene>
-        <!--View Controller-->
+        <!--Call Script View Controller-->
         <scene sceneID="ACz-2k-0uo">
             <objects>
                 <viewController storyboardIdentifier="callScriptController" id="2z3-FP-x6s" customClass="CallScriptViewController" customModule="FiveCalls" customModuleProvider="target" sceneMemberID="viewController">
@@ -581,7 +581,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="312"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="hfS-Bt-m9T" customClass="CopyWarningTextView" customModule="FiveCalls" customModuleProvider="target">
+                                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="justified" translatesAutoresizingMaskIntoConstraints="NO" id="hfS-Bt-m9T">
                                                     <rect key="frame" x="20" y="11" width="374" height="290"/>
                                                     <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
@@ -962,7 +962,7 @@ I'm calling to express my deep opposition to the confirmation of Betsy DeVos for
             </objects>
             <point key="canvasLocation" x="204" y="-352"/>
         </scene>
-        <!--Empty Data Set Delegate-->
+        <!--Issues View Controller-->
         <scene sceneID="f2u-8Z-uAT">
             <objects>
                 <viewController storyboardIdentifier="IssuesViewController" automaticallyAdjustsScrollViewInsets="NO" id="6eM-QQ-bGA" customClass="IssuesViewController" customModule="FiveCalls" customModuleProvider="target" sceneMemberID="viewController">
@@ -1091,7 +1091,7 @@ I'm calling to express my deep opposition to the confirmation of Betsy DeVos for
             </objects>
             <point key="canvasLocation" x="-503" y="612"/>
         </scene>
-        <!--Empty Data Set Delegate-->
+        <!--Issues View Controller-->
         <scene sceneID="23M-o3-6nx">
             <objects>
                 <viewController id="HbA-r8-FRB" customClass="IssuesViewController" customModule="FiveCalls" customModuleProvider="target" sceneMemberID="viewController">
@@ -1405,6 +1405,10 @@ to stay updated</string>
             <point key="canvasLocation" x="3518.840579710145" y="-227.44565217391306"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="6tF-q1-2tT"/>
+        <segue reference="Yf8-1x-xfZ"/>
+    </inferredMetricsTieBreakers>
     <resources>
         <image name="5calls-stars" width="35" height="35"/>
         <image name="gear" width="35" height="35"/>
@@ -1413,8 +1417,4 @@ to stay updated</string>
         <image name="share" width="19" height="27"/>
         <image name="share-topic" width="256" height="256"/>
     </resources>
-    <inferredMetricsTieBreakers>
-        <segue reference="6tF-q1-2tT"/>
-        <segue reference="Yf8-1x-xfZ"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/FiveCalls/FiveCalls/IssueScriptCell.swift
+++ b/FiveCalls/FiveCalls/IssueScriptCell.swift
@@ -9,23 +9,5 @@
 import UIKit
 
 class IssueScriptCell: UITableViewCell {
-
     @IBOutlet weak var scriptTextView: UITextView!
-    
-
-}
-
-class CopyWarningTextView: UITextView {
-    @IBOutlet weak var viewController: UIViewController?
-    
-    override func copy(_ sender: Any?) {
-        if !UserDefaults.standard.bool(forKey: UserDefaultsKey.hasWarnedAboutDangersOfCopying.rawValue) {
-            let alert = UIAlertController(title: R.string.localizable.thinkBeforeCopyingAlertTitle(), message: R.string.localizable.thinkBeforeCopyingAlertBody(), preferredStyle: .alert)
-            
-            alert.addAction(UIAlertAction(title:  R.string.localizable.okButtonTitle(), style: .cancel, handler: { action in }))
-            self.viewController?.present(alert, animated: true, completion: nil)
-            UserDefaults.standard.set(true, forKey: UserDefaultsKey.hasWarnedAboutDangersOfCopying.rawValue)
-        }
-        super.copy(sender)
-    }
 }

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -52,8 +52,6 @@
 "scheduled-reminders-description"     = "Turn these on to get a quick local reminder to make your 5 calls.";
 "line-busy"                           = "Local Offices ▼";
 "choose-a-number"                     = "Select a Different Office";
-"think-before-copying-alert-title"    = "Please Consider Before Texting, Faxing, or Emailing";
-"think-before-copying-alert-body"     = "Calling has been consistently shown to be the most effective way to make your voice heard with your Representatives.\n\nPlease consider this before using another method of communication.";
 "uncategorized-issues"                = "Uncategorized Issues";
 
 // outcomes

--- a/FiveCalls/FiveCalls/UserDefaultsKey.swift
+++ b/FiveCalls/FiveCalls/UserDefaultsKey.swift
@@ -18,8 +18,6 @@ enum UserDefaultsKey : String {
     case hasSeenFirstCallInstructions
     case reminderEnabled
 
-    case hasWarnedAboutDangersOfCopying
-
     case appVersion // The current CFBundleShortVersionString
     case countOfCallsForRatingPrompt
     


### PR DESCRIPTION
Fixes #301 

It causes a crash in certain cases on iPads and imho is not effective.