### PR TITLE
Specify time picker style to be .wheel on iOS 13.4+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     # The `macos` block requests that builds will run on a machine running
     # macOS with the specified version of Xcode installed
     macos:
-      xcode: '11.3.0'
+      xcode: '11.5.0'
     steps:
     # Machine Setup
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each

--- a/FiveCalls/FiveCalls/ScheduleRemindersController.swift
+++ b/FiveCalls/FiveCalls/ScheduleRemindersController.swift
@@ -120,6 +120,10 @@ class ScheduleRemindersController: UIViewController {
         navigationItem.rightBarButtonItem = switchButton(on: remindersEnabled)
         setOverlay(visible: !remindersEnabled, animated: false)
 
+        if #available(iOS 13.4, *) {
+            timePicker.preferredDatePickerStyle = .wheels
+        }
+
         timePicker.setValue(UIColor.fvc_darkBlue, forKey: "textColor")
     }
 


### PR DESCRIPTION
Fix #307

It seems the issue isn't the way that the text color is configured. Rather, the .compact style is
being used which doesn't have a `textColor` key.