### PR TITLE
Add weekend options for reminders

### DIFF
--- a/FiveCalls/FiveCalls/Base.lproj/About.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/About.storyboard
@@ -218,7 +218,7 @@
                                     <constraint firstAttribute="height" constant="50" id="hQX-ZO-baD"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="titlesString" value="Mon, Tue, Wed, Thur, Fri"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="titlesString" value="Sun, Mon, Tue, Wed, Thur, Fri, Sat"/>
                                     <userDefinedRuntimeAttribute type="color" keyPath="selectedBackgroundColor">
                                         <color key="value" name="darkBlue"/>
                                     </userDefinedRuntimeAttribute>

--- a/FiveCalls/FiveCalls/MultipleSelectionSegmentedControl.swift
+++ b/FiveCalls/FiveCalls/MultipleSelectionSegmentedControl.swift
@@ -58,7 +58,7 @@ class MultipleSelectionControl: UIControl {
             guard !title.isEmpty else { return nil }
             let button = UIButton()
             button.isSelected = false
-            button.setTitle(title, for: .normal)
+            button.setTitle(title.trimmingCharacters(in: .whitespaces), for: .normal)
             button.layer.borderWidth = 0.5
             button.layer.borderColor = selectedBackgroundColor.cgColor
             button.addTarget(self, action: #selector(buttonAction(_:)), for: .touchUpInside)

--- a/FiveCalls/FiveCalls/ScheduleRemindersController.swift
+++ b/FiveCalls/FiveCalls/ScheduleRemindersController.swift
@@ -203,7 +203,8 @@ class ScheduleRemindersController: UIViewController {
         let calendar = Calendar(identifier: .gregorian)
         return notifications.compactMap({ notification in
             if let calendarTrigger = notification.trigger as? UNCalendarNotificationTrigger {
-                return calendar.component(.weekday, from: (calendarTrigger.nextTriggerDate()!)) - 2
+                // again, converting from 1-indexed weekdays to 0-indexed segmented controls
+                return calendar.component(.weekday, from: (calendarTrigger.nextTriggerDate()!)) - 1
             }
             
             return nil
@@ -221,7 +222,8 @@ class ScheduleRemindersController: UIViewController {
     private func notificationTrigger(date: Date, dayIndex: Int) -> UNCalendarNotificationTrigger {
         var components = Calendar.current.dateComponents([.hour,.minute,.second], from: date)
         components.timeZone = TimeZone(identifier: "default")
-        components.weekday = dayIndex + 2
+        // segmented controls are zero-indexed while weekdays are 1-indexed, starting on Sunday
+        components.weekday = dayIndex + 1
         return UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
     }
 }


### PR DESCRIPTION
User asked us about our stance on calling on the weekends given that weekends are not a reminder option in the app. Weekends a great for calling and leaving VMs, so it makes sense to add them if people want to be reminded on the weekend.

Fixed a layout issue as well where extra spaces were being added into the button titles in the multi select segmented control.