### PR TITLE
Save the firebase id for when we remove firebase later

### DIFF
--- a/FiveCalls/FiveCalls/SessionManager.swift
+++ b/FiveCalls/FiveCalls/SessionManager.swift
@@ -20,6 +20,12 @@ class SessionManager {
     func startSession() {
         Auth.auth().signInAnonymously { result, error in
             self.userID = result?.user.uid
+            
+            // store the firebase id if the key is empty or nil, we'll trust that this is right when firebase is removed
+            let storedID = UserDefaults.standard.string(forKey: UserDefaultsKey.legacyFirebaseID.rawValue)
+            if storedID == nil || storedID == "" {
+                UserDefaults.standard.setValue(self.userID ?? "", forKey: UserDefaultsKey.legacyFirebaseID.rawValue)
+            }
 
             result?.user.getIDToken { token, tokenError in
                 self.idToken = token

--- a/FiveCalls/FiveCalls/UserDefaultsKey.swift
+++ b/FiveCalls/FiveCalls/UserDefaultsKey.swift
@@ -25,5 +25,6 @@ enum UserDefaultsKey : String {
 
     case selectIssuePath
     
+    case legacyFirebaseID // userid from firebase, for stats
     case callerID // an anoymous unique id
 }


### PR DESCRIPTION
Gonna remove firebase at some point but we'll do a release that saves the userID before then so when we move away we can still use it.