### PR TITLE
Fix build cycle error for Xcode 17

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -834,7 +834,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF",
 				"$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
 			);
 			name = "Run Script Crashlytics";


### PR DESCRIPTION
When building with Xcode 17 there is a error caused by a build cycle being detected.

Turns out this is an issue with the Crashlytics script and fixed with the suggestion here: https://github.com/firebase/firebase-ios-sdk/issues/11471