### PR TITLE
Remove broken open source libraries cell

### DIFF
--- a/FiveCalls/FiveCalls/AboutHtmlViewController.swift
+++ b/FiveCalls/FiveCalls/AboutHtmlViewController.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import UIKit
-//import CPDAcknowledgements
 import WebKit
 
 class AboutHtmlViewController : UIViewController {

--- a/FiveCalls/FiveCalls/AboutViewController.swift
+++ b/FiveCalls/FiveCalls/AboutViewController.swift
@@ -9,7 +9,6 @@
 import Foundation
 import UIKit
 import MessageUI
-//import CPDAcknowledgements
 import StoreKit
 
 class AboutViewController : UITableViewController, MFMailComposeViewControllerDelegate {
@@ -22,7 +21,6 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
     @IBOutlet weak var followOnTwitterCell: UITableViewCell!
     @IBOutlet weak var shareCell: UITableViewCell!
     @IBOutlet weak var rateCell: UITableViewCell!
-    @IBOutlet weak var openSourceCell: UITableViewCell!
     @IBOutlet weak var showWelcomeCell: UITableViewCell!
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -42,7 +40,6 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
         case followOnTwitterCell:   followOnTwitter()
         case shareCell:             shareApp(from: tableView.cellForRow(at: indexPath))
         case rateCell:              promptForRating()
-        case openSourceCell:        showOpenSource()
         case showWelcomeCell:       showWelcome()
             
         default: break;
@@ -107,12 +104,6 @@ class AboutViewController : UITableViewController, MFMailComposeViewControllerDe
     
     func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
         controller.dismiss(animated: true)
-    }
-    
-    func showOpenSource() {
-        AnalyticsManager.shared.trackEventOld(withName: "Screen: Open Source Libraries")
-//        let acknowledgementsVC = CPDAcknowledgementsViewController(style: nil, acknowledgements: nil, contributions: nil)
-//        navigationController?.pushViewController(acknowledgementsVC, animated: true)
     }
 
     func showWelcome() {

--- a/FiveCalls/FiveCalls/Base.lproj/About.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/About.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZRq-uX-bkA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZRq-uX-bkA">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,21 +14,21 @@
             <objects>
                 <tableViewController storyboardIdentifier="aboutViewController" id="VgL-ZE-5Pe" customClass="AboutViewController" customModule="FiveCalls" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="LpP-IY-SEA">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="General" id="BBO-LA-l1k">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="DTq-F1-o7Q" style="IBUITableViewCellStyleDefault" id="BAZ-ZL-0f2">
-                                        <rect key="frame" x="0.0" y="49.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="BAZ-ZL-0f2" id="uCW-Ac-rja">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Why Calling Works" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DTq-F1-o7Q">
-                                                    <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
                                                     <nil key="textColor"/>
@@ -41,14 +41,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="sxe-oe-rzP" style="IBUITableViewCellStyleDefault" id="dE7-CW-LJz">
-                                        <rect key="frame" x="0.0" y="93" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="99" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dE7-CW-LJz" id="YKc-fG-let">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Who Made 5 Calls?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="sxe-oe-rzP">
-                                                    <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
                                                     <nil key="textColor"/>
@@ -61,14 +61,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="fsr-dM-a58" style="IBUITableViewCellStyleDefault" id="7n8-Bn-OYc">
-                                        <rect key="frame" x="0.0" y="136.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="142.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7n8-Bn-OYc" id="JVv-NF-dGo">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fsr-dM-a58">
-                                                    <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
                                                     <nil key="textColor"/>
@@ -78,14 +78,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="KCN-KV-eLp" style="IBUITableViewCellStyleDefault" id="rrv-ij-hud">
-                                        <rect key="frame" x="0.0" y="180" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="186" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rrv-ij-hud" id="GYv-x9-lb8">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Show Welcome Screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KCN-KV-eLp">
-                                                    <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
                                                     <nil key="textColor"/>
@@ -99,14 +99,14 @@
                             <tableViewSection headerTitle="Social" footerTitle="Sharing and Rating helps others find 5 Calls." id="tQI-wN-vPy">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Wuz-VX-wE1" style="IBUITableViewCellStyleDefault" id="rZh-VI-0PQ">
-                                        <rect key="frame" x="0.0" y="281" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="293" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rZh-VI-0PQ" id="oKh-rP-WDa">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Follow on Twitter" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Wuz-VX-wE1">
-                                                    <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
                                                     <nil key="textColor"/>
@@ -116,14 +116,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="A80-KJ-jSE" style="IBUITableViewCellStyleDefault" id="xFl-TQ-224">
-                                        <rect key="frame" x="0.0" y="324.5" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="336.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xFl-TQ-224" id="QWE-H3-1rX">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Share with Others" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="A80-KJ-jSE">
-                                                    <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
                                                     <nil key="textColor"/>
@@ -133,14 +133,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="oYK-q2-p1A" style="IBUITableViewCellStyleDefault" id="2GH-ku-kt9">
-                                        <rect key="frame" x="0.0" y="368" width="375" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="380" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2GH-ku-kt9" id="vnH-6d-Yzd">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Please Rate 5 Calls" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="oYK-q2-p1A">
-                                                    <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
+                                                    <rect key="frame" x="16" y="0.0" width="324.5" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
                                                     <nil key="textColor"/>
@@ -151,26 +151,8 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection headerTitle="Credits" footerTitle="v1.2" id="3LS-4v-KSN">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="qbV-sg-nzX" style="IBUITableViewCellStyleDefault" id="r3a-g0-8z8">
-                                        <rect key="frame" x="0.0" y="477.5" width="375" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="r3a-g0-8z8" id="QIZ-kP-cgK">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Open Source Libraries" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qbV-sg-nzX">
-                                                    <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
+                            <tableViewSection footerTitle="v1.2" id="3LS-4v-KSN">
+                                <cells/>
                             </tableViewSection>
                         </sections>
                         <connections>
@@ -189,7 +171,6 @@
                     <connections>
                         <outlet property="feedbackCell" destination="7n8-Bn-OYc" id="CxY-gv-nbS"/>
                         <outlet property="followOnTwitterCell" destination="rZh-VI-0PQ" id="u0R-fm-21e"/>
-                        <outlet property="openSourceCell" destination="r3a-g0-8z8" id="G74-8Z-NvH"/>
                         <outlet property="rateCell" destination="2GH-ku-kt9" id="gqA-Xs-iTT"/>
                         <outlet property="shareCell" destination="xFl-TQ-224" id="qe3-xn-21E"/>
                         <outlet property="showWelcomeCell" destination="rrv-ij-hud" id="hi7-VJ-2h8"/>
@@ -237,7 +218,7 @@
                                 </connections>
                             </view>
                             <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="time" minuteInterval="10" translatesAutoresizingMaskIntoConstraints="NO" id="pgL-vc-xhW">
-                                <rect key="frame" x="0.0" y="104" width="375" height="160"/>
+                                <rect key="frame" x="0.0" y="124" width="375" height="160"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="160" id="cn6-EL-2Ax"/>
                                 </constraints>
@@ -246,7 +227,7 @@
                                 </connections>
                             </datePicker>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select what time of day you'd like to be reminded to make calls:" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LX5-gE-C8x">
-                                <rect key="frame" x="20" y="20" width="335" height="48"/>
+                                <rect key="frame" x="20" y="40" width="335" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <color key="textColor" name="darkBlueText"/>
                                 <nil key="highlightedColor"/>
@@ -300,11 +281,11 @@
                         <viewControllerLayoutGuide type="bottom" id="ABB-F9-WVu"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="OA2-xY-kOo">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GMQ-3m-Pwc">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
@@ -336,7 +317,7 @@
                 <navigationController storyboardIdentifier="aboutNavController" automaticallyAdjustsScrollViewInsets="NO" modalPresentationStyle="pageSheet" id="ZRq-uX-bkA" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" barStyle="black" translucent="NO" id="r70-ye-hKT">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" name="darkBlue"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -360,11 +341,11 @@
                         <viewControllerLayoutGuide type="bottom" id="c1H-g4-k9s"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="qCT-0T-4sC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O0l-7I-3xo">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>


### PR DESCRIPTION
|Before|After|
|-|-|
|![Simulator Screenshot - iPhone 14 Pro - 2023-09-06 at 11 41 31](https://github.com/5calls/ios/assets/810263/7b5f6ec8-f751-42c3-825c-443ad4ca7b95)|![Simulator Screenshot - iPhone 14 Pro - 2023-09-06 at 11 40 30](https://github.com/5calls/ios/assets/810263/fef1f7da-ec54-44ff-84d9-1594936fdc70)|

Removes "Credits" header and non-functional "Open Source Libraries" cell, preserving version footer.

It looks like CPDAcknowledgements is no longer being actively supported and there weren't any contributions being passed into it anyway.