### PR TITLE
Increase contrast of enable reminder text

### DIFF
--- a/FiveCalls/FiveCalls/ScheduleRemindersController.swift
+++ b/FiveCalls/FiveCalls/ScheduleRemindersController.swift
@@ -26,7 +26,7 @@ class ScheduleRemindersController: UIViewController {
         
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = R.color.mediumDarkGray()
+        label.textColor = R.color.darkGray()
         label.font = .fvc_body
         label.numberOfLines = 0
         label.text = R.string.localizable.scheduledRemindersDescription()

--- a/FiveCalls/FiveCalls/ScheduleRemindersController.swift
+++ b/FiveCalls/FiveCalls/ScheduleRemindersController.swift
@@ -26,7 +26,7 @@ class ScheduleRemindersController: UIViewController {
         
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.textColor = R.color.lightGray()
+        label.textColor = R.color.mediumDarkGray()
         label.font = .fvc_body
         label.numberOfLines = 0
         label.text = R.string.localizable.scheduledRemindersDescription()


### PR DESCRIPTION
Per [this issue](https://github.com/5calls/ios/issues/216), it's hard to distinguish the text from the background prior to enabling reminders.

I'm leaning towards Medium Dark Gray, although Dark Gray doesn't look bad either.

|Before (Light Gray)|After (Medium Dark Gray)|Medium|Dark Gray|
|-|-|-|-|
|![before](https://github.com/5calls/ios/assets/810263/922a5d20-55c9-449c-8517-066bcf6f7a9c)|![medium-dark-gray](https://github.com/5calls/ios/assets/810263/3a0d6f89-99dc-4b99-a944-28a580611f44)|![medium](https://github.com/5calls/ios/assets/810263/d0647e3e-a4aa-42b2-b3d9-be2be885ecd1)|![Dark-gray](https://github.com/5calls/ios/assets/810263/1f5f9287-2f2d-4ef1-8ab2-9694828bc55c)|
