### PR TITLE
Support setting a location on issue detail

### DIFF
--- a/FiveCalls/FiveCalls/Issue.swift
+++ b/FiveCalls/FiveCalls/Issue.swift
@@ -37,12 +37,7 @@ struct Issue: Identifiable, Decodable {
         var sortedContacts: [Contact] = []
         
         for area in sortedContactAreas(areas: contactAreas) {
-            // return standin contacts if we haven't loaded contacts yet
-            if allContacts.isEmpty {
-                sortedContacts.append(contentsOf: Contact.placeholderContact(for: area))
-            } else {
-                sortedContacts.append(contentsOf: allContacts.filter({ area == $0.area }))
-            }
+            sortedContacts.append(contentsOf: allContacts.filter({ area == $0.area }))
         }
 
         return sortedContacts

--- a/FiveCalls/FiveCalls/IssueDetail.swift
+++ b/FiveCalls/FiveCalls/IssueDetail.swift
@@ -14,6 +14,8 @@ struct IssueDetail: View {
     let issue: Issue
     let contacts: [Contact]
     
+    @State var showLocationSheet = false
+    
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -25,35 +27,53 @@ struct IssueDetail: View {
                     .padding(.bottom, 8)
                 Text(issue.markdownIssueReason)
                     .padding(.bottom, 16)
-                Text("Relevant representatives for this issue:")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.bottom, 2)
-                    .padding(.leading, 6)
-                VStack(spacing: 0) {
-                    ForEach(contacts.numbered(), id: \.element.id) { contact in
-                        ContactListItem(contact: contact.element, showComplete: (store.state.issueCompletion[issue.id] ?? []).contains(contact.element.id))
-                        if contact.number < 2 { Divider().padding(0) } else { EmptyView() }
+                if contacts.count > 0 {
+                    Text(R.string.localizable.repsListHeader())
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.bottom, 2)
+                        .padding(.leading, 6)
+                    VStack(spacing: 0) {
+                        ForEach(contacts.numbered(), id: \.element.id) { contact in
+                            ContactListItem(contact: contact.element, showComplete: (store.state.issueCompletion[issue.id] ?? []).contains(contact.element.id))
+                            if contact.number < 2 { Divider().padding(0) } else { EmptyView() }
+                        }
+                    }.background {
+                        RoundedRectangle(cornerRadius: 10)
+                            .foregroundColor(Color(red: 0.85, green: 0.85, blue: 0.85))
+                    }.padding(.bottom, 16)
+                    NavigationLink(value: IssueDetailNavModel(issue: issue, contacts: contacts)) {
+                        PrimaryButton(title: R.string.localizable.seeScript(), systemImageName: "megaphone.fill")
                     }
-                }.background {
-                    RoundedRectangle(cornerRadius: 10)
-                        .foregroundColor(Color(red: 0.85, green: 0.85, blue: 0.85))
-                }.padding(.bottom, 16)
-                NavigationLink(value: IssueDetailNavModel(issue: issue, contacts: contacts)) {
-                    PrimaryButton(title: R.string.localizable.seeScript(), systemImageName: "megaphone.fill")
+                } else {
+                    Text(R.string.localizable.setLocationHeader())
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.bottom, 2)
+                        .padding(.leading, 6)
+                    Button(action: {
+                        showLocationSheet.toggle()
+                    }, label: {
+                        PrimaryButton(title: R.string.localizable.setLocationButton(), systemImageName: "location.circle.fill")
+                    })
                 }
             }.padding(.horizontal)
         }
-.navigationBarHidden(true)
+        .navigationBarHidden(true)
         .clipped()
+        .sheet(isPresented: $showLocationSheet) {
+            LocationSheet()
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.visible)
+                .padding(.top, 40)
+            Spacer()
+        }
     }
 }
 
-struct IssueDetail_Previews: PreviewProvider {
-    static var previews: some View {
-        IssueDetail(issue: Issue.multilinePreviewIssue, contacts: [.housePreviewContact,.senatePreviewContact1,.senatePreviewContact2])
-            .environmentObject(Store(state: AppState()))
-    }
+#Preview {
+    IssueDetail(issue: Issue.multilinePreviewIssue, contacts: [.housePreviewContact,.senatePreviewContact1,.senatePreviewContact2])
+        .environmentObject(Store(state: AppState()))
 }
 
 struct IssueDetailNavModel {

--- a/FiveCalls/FiveCalls/IssueListItem.swift
+++ b/FiveCalls/FiveCalls/IssueListItem.swift
@@ -23,7 +23,9 @@ struct IssueListItem: View {
                         .multilineTextAlignment(.leading)
                     Spacer()
                     HStack(spacing: 0) {
-                        let contactsForIssue = issue.contactsForIssue(allContacts: contacts)
+                        let contactsForIssue = contacts.isEmpty ? issue.contactAreas.flatMap({ area in
+                            Contact.placeholderContact(for: area)
+                        }) : issue.contactsForIssue(allContacts: contacts)
                         ForEach(contactsForIssue.numbered()) { numberedContact in
                             ContactCircle(contact: numberedContact.element, issueID: issue.id)
                                 .frame(width: 20, height: 20)

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -139,6 +139,11 @@
 "welcome-page-2-calls"                = "Together we've made\n%@ calls";
 "welcome-page-2-button-title"         = "Get Started";
 
+// issue detail
+"set-location-header"                 = "We need a location to find your reps";
+"set-location-button"                 = "Set your location";
+"reps-list-header"                    = "Relevant representatives for this issue";
+
 // done
 "done-title"                          = "You called on **%@**";
 "total-calls"                         = "Total calls";


### PR DESCRIPTION
Moved where we load placeholder contacts into the issuelistitem directly, rather than returning placeholder issues whenever we tried to get contacts. We want to know when there are no contacts loaded yet in most cases.

Then added the location sheet to the issue detail page where you can set your location inline and... it just works! This is really the magic of unidirectional data flow.

Fixes #368 