### PR TITLE
Add plausible events back in

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		B5E7626C1E40D72400D63D62 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				D09AA8052B0497C70012FF45 /* UNNotification+ScheduleReminders.swift */,
 				B5E762701E40D8DD00D63D62 /* JSONSerializable.swift */,
 				B5E762681E40D63800D63D62 /* Issue.swift */,
 				D029C6CF1F6F42EA00E56CC7 /* Outcome.swift */,

--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -409,7 +409,6 @@
 		B5E7626C1E40D72400D63D62 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				D09AA8052B0497C70012FF45 /* UNNotification+ScheduleReminders.swift */,
 				B5E762701E40D8DD00D63D62 /* JSONSerializable.swift */,
 				B5E762681E40D63800D63D62 /* Issue.swift */,
 				D029C6CF1F6F42EA00E56CC7 /* Outcome.swift */,

--- a/FiveCalls/FiveCalls/AboutSheet.swift
+++ b/FiveCalls/FiveCalls/AboutSheet.swift
@@ -44,7 +44,6 @@ struct AboutSheet: View {
 
                     }
                     AboutListItem(title: R.string.localizable.aboutItemFeedback()) {
-                        AnalyticsManager.shared.trackEventOld(withName: "Action: Feedback")
                         if EmailComposerView.canSendEmail() {
                             showEmailComposer = true
                         } else {
@@ -113,14 +112,12 @@ struct AboutSheet: View {
     }
     
     func followOnTwitter() {
-        AnalyticsManager.shared.trackEventOld(withName: "Action: Follow On Twitter")
         guard let url = URL(string: "https://twitter.com/make5calls") else { return }
         UIApplication.shared.open(url)
     }
 
     
     func requestReview() {
-        AnalyticsManager.shared.trackEventOld(withName: "Action: Rate the App")
         guard let currentScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
             return
         }

--- a/FiveCalls/FiveCalls/AnalyticsManager.swift
+++ b/FiveCalls/FiveCalls/AnalyticsManager.swift
@@ -40,16 +40,7 @@ class AnalyticsManager {
         try? plausible?.trackEvent(event: name, path: path, properties: properties.merging(alwaysUseProperties) { _, new in new })
         #endif
     }
-    
-    // not quite ready to remove all the references to this, but I don't want to push these all to plausible immediately
-    func trackEventOld(withName name: String, andProperties properties: [String: String] = [:]) {
-        #if !DEBUG
-        // firebase does not support colons in event names...
-//        let sanitizedEventName = name.replacingOccurrences(of: ":", with: "_").replacingOccurrences(of: " ", with: "")
-//        Analytics.logEvent(sanitizedEventName, parameters: properties)
-        #endif
-    }
-    
+        
     func trackError(error: Error) {
         // no remote error tracking right now
     }

--- a/FiveCalls/FiveCalls/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppDelegate.swift
@@ -57,7 +57,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         // sets a string like 'usps-postal-service-covid-funding' that we can use when issues are loaded
         UserDefaults.standard.set(incomingURL.lastPathComponent, forKey: UserDefaultsKey.selectIssuePath.rawValue)
-        AnalyticsManager.shared.trackEventOld(withName: "Info: Enter from Universal Link", andProperties: ["issue-slug": incomingURL.lastPathComponent])
 
         return true
     }

--- a/FiveCalls/FiveCalls/Dashboard.swift
+++ b/FiveCalls/FiveCalls/Dashboard.swift
@@ -49,6 +49,8 @@ struct Dashboard: View {
         }
         .navigationBarHidden(true)
         .onAppear() {
+            AnalyticsManager.shared.trackPageview(path: "/")
+            
             // TODO: refresh if issues are old too?
             if store.state.issues.isEmpty {
                 store.dispatch(action: .FetchIssues)

--- a/FiveCalls/FiveCalls/IssueDetail.swift
+++ b/FiveCalls/FiveCalls/IssueDetail.swift
@@ -68,6 +68,9 @@ struct IssueDetail: View {
                 .padding(.top, 40)
             Spacer()
         }
+        .onAppear() {
+            AnalyticsManager.shared.trackPageview(path: "/issue/\(issue.slug)/")
+        }
     }
 }
 

--- a/FiveCalls/FiveCalls/IssueDone.swift
+++ b/FiveCalls/FiveCalls/IssueDone.swift
@@ -78,6 +78,8 @@ struct IssueDone: View {
         .clipped()
         .frame(maxWidth: 500)
         .onAppear() {
+            AnalyticsManager.shared.trackPageview(path: "/issue/\(issue.slug)/done/")
+            
             store.dispatch(action: .FetchStats(issue.id))
         }
     }

--- a/FiveCalls/FiveCalls/ScheduleReminders.swift
+++ b/FiveCalls/FiveCalls/ScheduleReminders.swift
@@ -103,7 +103,9 @@ struct ScheduleReminders: View {
     private func requestNotificationAccess() {
         let options: UNAuthorizationOptions = [.alert, .sound, .badge];
         UNUserNotificationCenter.current().requestAuthorization(options: options) { (success, error) in
-            AnalyticsManager.shared.trackEventOld(withName: "Notification Access", andProperties: ["success": "\(success)"])
+            if success {
+                AnalyticsManager.shared.trackEvent(name: "push-subscribe", path: "/reminders/")
+            }
         }
     }
     

--- a/FiveCalls/FiveCalls/WebView.swift
+++ b/FiveCalls/FiveCalls/WebView.swift
@@ -48,7 +48,6 @@ struct WebView: UIViewRepresentable {
                     decisionHandler(.allow)
                     return
                 }
-                AnalyticsManager.shared.trackEventOld(withName: "Action: Open External Link", andProperties: ["url":url.absoluteString])
                 UIApplication.shared.open(url)
                 
                 decisionHandler(.cancel)


### PR DESCRIPTION
Removed some old events we never ended up caring about, and removed tracking the contact pages (i.e. calling about issue x to contact y). We can construct that data from the call results if we want to, I'd rather stick to the basics with plausible, mostly how many unique people are flowing across all platforms.