### PR TITLE
Re-integrated rating and push prompt on done

### DIFF
--- a/FiveCalls/FiveCalls/IssueDone.swift
+++ b/FiveCalls/FiveCalls/IssueDone.swift
@@ -100,9 +100,10 @@ struct IssueDone: View {
         }.alert(R.string.localizable.notificationTitle(), isPresented: $showNotificationAlert) {
             Button {
                 // we don't really care which issue they were on when they subbed, just that it was a done page
-                AnalyticsManager.shared.trackEvent(name: "push-subscribe", path: "/issue/x/done/")
-                OneSignal.promptForPushNotifications(userResponse: { (success) in
-                    //
+                OneSignal.promptForPushNotifications(userResponse: { success in
+                    if success {
+                        AnalyticsManager.shared.trackEvent(name: "push-subscribe", path: "/issue/x/done/")
+                    }
                 })
             } label: {
                 Text(R.string.localizable.notificationImportant())

--- a/FiveCalls/FiveCalls/IssueDone.swift
+++ b/FiveCalls/FiveCalls/IssueDone.swift
@@ -7,11 +7,15 @@
 //
 
 import SwiftUI
+import StoreKit
+import OneSignal
 
 struct IssueDone: View {
     @EnvironmentObject var store: Store
     @EnvironmentObject var router: IssueRouter
     @Environment(\.openURL) private var openURL
+    
+    @State var showNotificationAlert = false
     
     let issue: Issue
     
@@ -24,10 +28,10 @@ struct IssueDone: View {
             self.markdownTitle = AttributedString(R.string.localizable.doneScreenTitle())
         }
     }
-        
+    
     let donateURL = URL(string: "https://secure.actblue.com/donate/5calls-donate?refcode=ios&refcode2=\(AnalyticsManager.shared.callerID)")!
     var markdownTitle: AttributedString!
-    
+        
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
@@ -81,7 +85,58 @@ struct IssueDone: View {
             AnalyticsManager.shared.trackPageview(path: "/issue/\(issue.slug)/done/")
             
             store.dispatch(action: .FetchStats(issue.id))
+         
+            // will prompt for a rating after hitting done 5 times
+            RatingPromptCounter.increment {
+                guard let currentScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+                    return
+                }
+                
+                SKStoreReviewController.requestReview(in: currentScene)
+            }
+            
+            // unlikely to occur at the same time as the rating prompt counter
+            checkForNotifications()
+        }.alert(R.string.localizable.notificationTitle(), isPresented: $showNotificationAlert) {
+            Button {
+                // we don't really care which issue they were on when they subbed, just that it was a done page
+                AnalyticsManager.shared.trackEvent(name: "push-subscribe", path: "/issue/x/done/")
+                OneSignal.promptForPushNotifications(userResponse: { (success) in
+                    //
+                })
+            } label: {
+                Text(R.string.localizable.notificationImportant())
+            }
+            Button {
+                let key = UserDefaultsKey.lastAskedForNotificationPermission.rawValue
+                UserDefaults.standard.set(Date(), forKey: key)
+            } label: {
+                Text(R.string.localizable.notificationNone())
+            }
+
+        } message: {
+            Text(R.string.localizable.notificationAsk())
         }
+
+    }
+}
+
+
+
+extension IssueDone {
+    func checkForNotifications() {
+            let deviceState = OneSignal.getDeviceState()
+            let nextPrompt = nextNotificationPromptDate() ?? Date()
+                    
+            if deviceState?.hasNotificationPermission == false && nextPrompt <= Date() {
+                showNotificationAlert = true
+            }
+        }
+    func nextNotificationPromptDate() -> Date? {
+        let key = UserDefaultsKey.lastAskedForNotificationPermission.rawValue
+        guard let lastPrompt = UserDefaults.standard.object(forKey: key) as? Date else { return nil }
+        
+        return Calendar.current.date(byAdding: .month, value: 1, to: lastPrompt)
     }
 }
 

--- a/FiveCalls/FiveCalls/RatingPromptCounter.swift
+++ b/FiveCalls/FiveCalls/RatingPromptCounter.swift
@@ -9,11 +9,9 @@
 import Foundation
 
 struct RatingPromptCounter {
-    private let threshold = 5
+    private static let threshold = 5
 
-    let handler: (() -> Void)?
-
-    func increment() {
+    static func increment(handler: () -> Void) {
         let defaults = UserDefaults.standard
         let key = UserDefaultsKey.countOfCallsForRatingPrompt.rawValue
         let count = defaults.integer(forKey: key) + 1
@@ -23,7 +21,7 @@ struct RatingPromptCounter {
         defaults.set(count, forKey: key)
 
         if count == threshold {
-            handler?()
+            handler()
         }
     }
 }


### PR DESCRIPTION
RatingPromptCounter is now static so we can use it without a view model on the done page. I would probably want some more concurrency checks if this was used in more places but it's just on the one page so should be fine.

Fixes #379, #380