### PR TITLE
Added contact summary back to the done page

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		D0BFE9C72A7C9434007203A3 /* ContactCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BFE9C62A7C9434007203A3 /* ContactCircle.swift */; };
 		D0BFE9C92A7C9C21007203A3 /* ContactImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BFE9C82A7C9C21007203A3 /* ContactImages.swift */; };
 		D0BFE9CB2A7DD25C007203A3 /* LocationHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BFE9CA2A7DD25C007203A3 /* LocationHeader.swift */; };
+		D0C2DDE32B1D5B2E0031A18E /* ContactListItemCompact.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C2DDE22B1D5B2E0031A18E /* ContactListItemCompact.swift */; };
 		D0C3C2722A8744EC005528B0 /* IssueContactDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C3C2712A8744EC005528B0 /* IssueContactDetail.swift */; };
 		D0C465D12AD30ACB00CE3E65 /* IssueNavigationHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C465D02AD30ACB00CE3E65 /* IssueNavigationHeader.swift */; };
 		D0C465D32AD30BEE00CE3E65 /* IssueRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C465D22AD30BEE00CE3E65 /* IssueRouter.swift */; };
@@ -242,6 +243,7 @@
 		D0BFE9C62A7C9434007203A3 /* ContactCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCircle.swift; sourceTree = "<group>"; };
 		D0BFE9C82A7C9C21007203A3 /* ContactImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactImages.swift; sourceTree = "<group>"; };
 		D0BFE9CA2A7DD25C007203A3 /* LocationHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationHeader.swift; sourceTree = "<group>"; };
+		D0C2DDE22B1D5B2E0031A18E /* ContactListItemCompact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactListItemCompact.swift; sourceTree = "<group>"; };
 		D0C3C2712A8744EC005528B0 /* IssueContactDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueContactDetail.swift; sourceTree = "<group>"; };
 		D0C465D02AD30ACB00CE3E65 /* IssueNavigationHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueNavigationHeader.swift; sourceTree = "<group>"; };
 		D0C465D22AD30BEE00CE3E65 /* IssueRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueRouter.swift; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 				4F4868BA2AC3A3B400E1733A /* AboutListItem.swift */,
 				D0BFE9C62A7C9434007203A3 /* ContactCircle.swift */,
 				D0002E162A9DB34D0098973F /* ContactListItem.swift */,
+				D0C2DDE22B1D5B2E0031A18E /* ContactListItemCompact.swift */,
 				4F4868BC2AC3A3E900E1733A /* EmailComposerView.swift */,
 				D0480B1D2A4D493B00502818 /* IssueListItem.swift */,
 				D0C465D02AD30ACB00CE3E65 /* IssueNavigationHeader.swift */,
@@ -804,6 +807,7 @@
 				B512506A21E6F762007D32DF /* FetchContactsOperation.swift in Sources */,
 				4F4868BB2AC3A3B400E1733A /* AboutListItem.swift in Sources */,
 				B5E762731E40DC5800D63D62 /* FetchIssuesOperation.swift in Sources */,
+				D0C2DDE32B1D5B2E0031A18E /* ContactListItemCompact.swift in Sources */,
 				D0480B212A4D4B0400502818 /* PreviewIssues.swift in Sources */,
 				B5E98E351E529E66005221B7 /* functions.swift in Sources */,
 				D0480B1E2A4D493B00502818 /* IssueListItem.swift in Sources */,

--- a/FiveCalls/FiveCalls.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FiveCalls/FiveCalls.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "pins" : [
+    {
+      "identity" : "onesignal-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OneSignal/OneSignal-iOS-SDK",
+      "state" : {
+        "revision" : "8e4e32f69d4cc8b3543040473aeebdc08ebfa7bf",
+        "version" : "3.11.1"
+      }
+    },
+    {
+      "identity" : "plausibleswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nickoneill/PlausibleSwift",
+      "state" : {
+        "revision" : "522268b34b7f9ec4ebbe23a0209e74f6fbdc203e",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "r.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mac-cain13/R.swift/",
+      "state" : {
+        "revision" : "a76220f2c4b73bdda670f4a318c6ec983399ac6d",
+        "version" : "7.4.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "xcodeedit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tomlokhorst/XcodeEdit",
+      "state" : {
+        "revision" : "b6b67389a0f1a6fdd9c6457a8ab5b02eaab13c5c",
+        "version" : "2.9.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/FiveCalls/FiveCalls/AppState.swift
+++ b/FiveCalls/FiveCalls/AppState.swift
@@ -76,3 +76,15 @@ class AppState: ObservableObject, ReduxState {
         }
     }
 }
+
+extension AppState {
+    func issueCalledOn(issueID: Int, contactID: String) -> Bool {
+        // a contact outcome is a contactid concatenated with an outcome (B0001234-contact)
+        let contactOutcomesForIssue = self.issueCompletion[issueID] ?? []
+        let contactIDs = contactOutcomesForIssue.map { contactOutcome in
+            return String(contactOutcome.split(separator: "-").first ?? "")
+        }
+
+        return contactIDs.contains(contactID)
+    }
+}

--- a/FiveCalls/FiveCalls/AppState.swift
+++ b/FiveCalls/FiveCalls/AppState.swift
@@ -13,7 +13,7 @@ import os
 class AppState: ObservableObject, ReduxState {
     @Published var globalCallCount: Int = 0
     @Published var issueCallCounts: [Int: Int] = [:]
-    // issueCompletion is a local cache of completed calls: an array of contact ids keyed by an issue id
+    // issueCompletion is a local cache of completed calls: an array of contact id and outcomes (B0001234-contact) keyed by an issue id
     @Published var issueCompletion: [Int: [String]] = [:] {
         didSet {
             // NSNumber (bridged automatically from Int) is not supported as a key in a plist dictionary, so we stringify and unstringify

--- a/FiveCalls/FiveCalls/Contact.swift
+++ b/FiveCalls/FiveCalls/Contact.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RswiftResources
 
 struct Contact : Decodable {
     let id: String
@@ -124,7 +125,7 @@ extension Contact {
 extension Contact {
     static func placeholderContact(for area: String) -> [Contact] {
         switch area {
-        case "US House":
+        case "US Senate":
             return [
                     Contact(id: "1234", area: area, name: area, party: area, phone: "", photoURL: nil, fieldOffices: []),
                     Contact(id: "1235", area: area, name: area, party: area, phone: "", photoURL: nil, fieldOffices: [])

--- a/FiveCalls/FiveCalls/ContactCircle.swift
+++ b/FiveCalls/FiveCalls/ContactCircle.swift
@@ -20,7 +20,7 @@ struct ContactCircle: View {
     }
     
     var body: some View {
-        if let issueID, issueCalledOn(issueID: issueID, contactID: contact.id) {
+        if let issueID, store.state.issueCalledOn(issueID: issueID, contactID: contact.id) {
             Image(systemName: "checkmark.circle.fill")
                 .resizable()
                 .foregroundColor(.fivecallsGreen)
@@ -49,17 +49,6 @@ struct ContactCircle: View {
                 Circle()
             }
     }
-    
-    func issueCalledOn(issueID: Int, contactID: String) -> Bool {
-        // a contact outcome is a contactid concatenated with an outcome (B0001234-contact)
-        let contactOutcomesForIssue = store.state.issueCompletion[issueID] ?? []
-        let contactIDs = contactOutcomesForIssue.map { contactOutcome in
-            return String(contactOutcome.split(separator: "-").first ?? "")
-        }
-
-        return contactIDs.contains(contactID)
-    }
-
 }
 
 #Preview {

--- a/FiveCalls/FiveCalls/ContactCircle.swift
+++ b/FiveCalls/FiveCalls/ContactCircle.swift
@@ -20,7 +20,7 @@ struct ContactCircle: View {
     }
     
     var body: some View {
-        if let issueID, (store.state.issueCompletion[issueID] ?? []).contains(contact.id) {
+        if let issueID, issueCalledOn(issueID: issueID, contactID: contact.id) {
             Image(systemName: "checkmark.circle.fill")
                 .resizable()
                 .foregroundColor(.fivecallsGreen)
@@ -49,12 +49,23 @@ struct ContactCircle: View {
                 Circle()
             }
     }
+    
+    func issueCalledOn(issueID: Int, contactID: String) -> Bool {
+        // a contact outcome is a contactid concatenated with an outcome (B0001234-contact)
+        let contactOutcomesForIssue = store.state.issueCompletion[issueID] ?? []
+        let contactIDs = contactOutcomesForIssue.map { contactOutcome in
+            return String(contactOutcome.split(separator: "-").first ?? "")
+        }
+
+        return contactIDs.contains(contactID)
+    }
+
 }
 
 #Preview {
     let storeWithCompletedIssues: Store = {
         let state = AppState()
-        state.issueCompletion[123] = ["1234"]
+        state.issueCompletion[123] = ["1234-contact"]
         return Store(state: state)
     }()
     

--- a/FiveCalls/FiveCalls/ContactListItemCompact.swift
+++ b/FiveCalls/FiveCalls/ContactListItemCompact.swift
@@ -1,0 +1,58 @@
+//
+//  ContactListItemCompact.swift
+//  FiveCalls
+//
+//  Created by Nick O'Neill on 12/3/23.
+//  Copyright © 2023 5calls. All rights reserved.
+//
+
+import SwiftUI
+
+struct ContactListItemCompact: View {
+    let contact: Contact
+    let issueCompletions: [String]
+    
+    var body: some View {
+        HStack {
+            ContactCircle(contact: contact)
+                .frame(width: 25, height: 25)
+                .padding(.vertical, 4)
+                .padding(.trailing, 4)
+                .overlay {
+                    if latestOutcomeForContact(contactID: contact.id, issueCompletions: issueCompletions) != "Skip" {
+                        Image(systemName: "checkmark.circle.fill")
+                            .frame(width: 10, height: 10)
+                            .foregroundColor(.fivecallsGreen)
+                            .background {
+                                Circle().foregroundColor(.white)
+                            }
+                            .offset(x: 7, y: 7)
+                    }
+                }
+            VStack(alignment: .leading) {
+                Text(contact.name)
+                    .fontWeight(.semibold)
+                Text(latestOutcomeForContact(contactID: contact.id, issueCompletions: issueCompletions))
+                    .font(.caption)
+            }
+        }
+    }
+    
+    func latestOutcomeForContact(contactID: String, issueCompletions: [String]) -> String {
+        if let contactOutcome = issueCompletions.last(where: { $0.split(separator: "-")[0] == contactID }) {
+            if contactOutcome.split(separator: "-").count > 1 {
+                return ContactLog.localizedOutcomeForStatus(status: String(contactOutcome.split(separator: "-")[1]))
+            }
+        }
+        
+        return R.string.localizable.outcomesSkip()
+    }
+
+}
+
+#Preview {
+    VStack {
+        ContactListItemCompact(contact: .housePreviewContact, issueCompletions: ["\(Contact.housePreviewContact.id)-vm"])
+        ContactListItemCompact(contact: .housePreviewContact, issueCompletions: ["B0001234-vm"])
+    }
+}

--- a/FiveCalls/FiveCalls/ContactListItemCompact.swift
+++ b/FiveCalls/FiveCalls/ContactListItemCompact.swift
@@ -12,6 +12,19 @@ struct ContactListItemCompact: View {
     let contact: Contact
     let issueCompletions: [String]
     
+    var latestOutcomeForContact: String {
+        if let contactOutcome = issueCompletions.last(where: { $0.split(separator: "-")[0] == contact.id }) {
+            if contactOutcome.split(separator: "-").count > 1 {
+                return ContactLog.localizedOutcomeForStatus(status: String(contactOutcome.split(separator: "-")[1]))
+            }
+        }
+        
+        return R.string.localizable.outcomesSkip()
+    }
+    var shouldShowImage: Bool {
+        return latestOutcomeForContact != "Skip"
+    }
+    
     var body: some View {
         HStack {
             ContactCircle(contact: contact)
@@ -19,7 +32,7 @@ struct ContactListItemCompact: View {
                 .padding(.vertical, 4)
                 .padding(.trailing, 4)
                 .overlay {
-                    if latestOutcomeForContact(contactID: contact.id, issueCompletions: issueCompletions) != "Skip" {
+                    if shouldShowImage {
                         Image(systemName: "checkmark.circle.fill")
                             .frame(width: 10, height: 10)
                             .foregroundColor(.fivecallsGreen)
@@ -32,22 +45,11 @@ struct ContactListItemCompact: View {
             VStack(alignment: .leading) {
                 Text(contact.name)
                     .fontWeight(.semibold)
-                Text(latestOutcomeForContact(contactID: contact.id, issueCompletions: issueCompletions))
+                Text(latestOutcomeForContact)
                     .font(.caption)
             }
         }
     }
-    
-    func latestOutcomeForContact(contactID: String, issueCompletions: [String]) -> String {
-        if let contactOutcome = issueCompletions.last(where: { $0.split(separator: "-")[0] == contactID }) {
-            if contactOutcome.split(separator: "-").count > 1 {
-                return ContactLog.localizedOutcomeForStatus(status: String(contactOutcome.split(separator: "-")[1]))
-            }
-        }
-        
-        return R.string.localizable.outcomesSkip()
-    }
-
 }
 
 #Preview {

--- a/FiveCalls/FiveCalls/ContactLog.swift
+++ b/FiveCalls/FiveCalls/ContactLog.swift
@@ -17,8 +17,8 @@ struct ContactLog : Hashable, Codable {
     let date: Date
     let reported: Bool
     
-    var localizedOutcome: String {
-        switch self.outcome {
+    static func localizedOutcomeForStatus(status: String) -> String {
+        switch status {
         case "vm", "voicemail":
             return R.string.localizable.outcomesVoicemail()
         case "contact", "contacted":
@@ -32,6 +32,7 @@ struct ContactLog : Hashable, Codable {
         }
     }
 }
+
 
 struct LegacyPantryWrapper: Codable {
     let expires: Int

--- a/FiveCalls/FiveCalls/IssueContactDetail.swift
+++ b/FiveCalls/FiveCalls/IssueContactDetail.swift
@@ -77,7 +77,7 @@ struct IssueContactDetail: View {
                     NavigationLink(value: IssueNavModel(issue: issue, type: "done")) {
                         OutcomesView(outcomes: issue.outcomeModels, report:
                             { outcome in
-                                let log = ContactLog(issueId: String(issue.id), contactId: currentContact.id, phone: "", outcome: outcome.status, date: Date(), reported: true)
+                            let log = ContactLog(issueId: String(issue.id), contactId: currentContact.id, phone: "", outcome: outcome.status, date: Date(), reported: true)
                             store.dispatch(action: .ReportOutcome(issue, log, outcome))
                             router.path.append(IssueNavModel(issue: issue, type: "done"))
                         })

--- a/FiveCalls/FiveCalls/IssueDetail.swift
+++ b/FiveCalls/FiveCalls/IssueDetail.swift
@@ -35,7 +35,7 @@ struct IssueDetail: View {
                         .padding(.leading, 6)
                     VStack(spacing: 0) {
                         ForEach(contacts.numbered(), id: \.element.id) { contact in
-                            ContactListItem(contact: contact.element, showComplete: issueCalledOn(issueID: issue.id, contactID: contact.id))
+                            ContactListItem(contact: contact.element, showComplete: store.state.issueCalledOn(issueID: issue.id, contactID: contact.id))
                             if contact.number < 2 { Divider().padding(0) } else { EmptyView() }
                         }
                     }.background {
@@ -71,16 +71,6 @@ struct IssueDetail: View {
         .onAppear() {
             AnalyticsManager.shared.trackPageview(path: "/issue/\(issue.slug)/")
         }
-    }
-    
-    func issueCalledOn(issueID: Int, contactID: String) -> Bool {
-        // a contact outcome is a contactid concatenated with an outcome (B0001234-contact)
-        let contactOutcomesForIssue = store.state.issueCompletion[issueID] ?? []
-        let contactIDs = contactOutcomesForIssue.map { contactOutcome in
-            return String(contactOutcome.split(separator: "-").first ?? "")
-        }
-
-        return contactIDs.contains(contactID)
     }
 }
 

--- a/FiveCalls/FiveCalls/IssueDetail.swift
+++ b/FiveCalls/FiveCalls/IssueDetail.swift
@@ -35,7 +35,7 @@ struct IssueDetail: View {
                         .padding(.leading, 6)
                     VStack(spacing: 0) {
                         ForEach(contacts.numbered(), id: \.element.id) { contact in
-                            ContactListItem(contact: contact.element, showComplete: (store.state.issueCompletion[issue.id] ?? []).contains(contact.element.id))
+                            ContactListItem(contact: contact.element, showComplete: issueCalledOn(issueID: issue.id, contactID: contact.id))
                             if contact.number < 2 { Divider().padding(0) } else { EmptyView() }
                         }
                     }.background {
@@ -71,6 +71,16 @@ struct IssueDetail: View {
         .onAppear() {
             AnalyticsManager.shared.trackPageview(path: "/issue/\(issue.slug)/")
         }
+    }
+    
+    func issueCalledOn(issueID: Int, contactID: String) -> Bool {
+        // a contact outcome is a contactid concatenated with an outcome (B0001234-contact)
+        let contactOutcomesForIssue = store.state.issueCompletion[issueID] ?? []
+        let contactIDs = contactOutcomesForIssue.map { contactOutcome in
+            return String(contactOutcome.split(separator: "-").first ?? "")
+        }
+
+        return contactIDs.contains(contactID)
     }
 }
 

--- a/FiveCalls/FiveCalls/IssueDone.swift
+++ b/FiveCalls/FiveCalls/IssueDone.swift
@@ -49,6 +49,11 @@ struct IssueDone: View {
                             .padding(.bottom, 14)
                     }
                 }.padding(.bottom, 16)
+                Text(R.string.localizable.contactSummaryHeader())
+                    .font(.caption).fontWeight(.bold)
+                ForEach(issue.contactsForIssue(allContacts: store.state.contacts)) { contact in
+                    ContactListItemCompact(contact: contact, issueCompletions: store.state.issueCompletion[issue.id] ?? [])
+                }.padding(.bottom, 8)
                 if store.state.donateOn {
                     Text(R.string.localizable.support5calls())
                         .font(.caption).fontWeight(.bold)
@@ -201,7 +206,15 @@ struct CountingView: View {
 }
 
 #Preview {
-    IssueDone(issue: .basicPreviewIssue)
+    let previewState = {
+        let state = AppState()
+        state.contacts = [.housePreviewContact, .senatePreviewContact1, .senatePreviewContact2]
+        state.issueCompletion[Issue.basicPreviewIssue.id] = ["\(Contact.housePreviewContact.id)-voicemail","\(Contact.senatePreviewContact1.id)-contact"]
+        return state
+    }()
+
+    return IssueDone(issue: .basicPreviewIssue)
+        .environmentObject(Store(state: previewState))
 }
 
 struct IssueNavModel {

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -169,6 +169,7 @@
 "share-this-topic"                    = "Share this topic";
 "done-screen-button"                  = "Done";
 "done-screen-title"                   = "Nice work!";
+"contact-summary-header"              = "Contacts";
 
 // nav
 "back"                                = "Back";

--- a/FiveCalls/FiveCalls/Middleware.swift
+++ b/FiveCalls/FiveCalls/Middleware.swift
@@ -22,7 +22,7 @@ func appMiddleware() -> Middleware<AppState> {
             // TODO: migrate ContactLog issueId to Int after UIKit is gone
             // this is always generated in swiftUI from an int so it should always succeed
             if let issueId = Int(contactLog.issueId), outcome.status != "skip" {
-                dispatch(.SetIssueContactCompletion(issueId, contactLog.contactId))
+                dispatch(.SetIssueContactCompletion(issueId, "\(contactLog.contactId)-\(outcome.status)"))
             }
             AnalyticsManager.shared.trackEvent(name: "Outcome-\(outcome.status)", path: "/issues/\(issue.slug)/")
             reportOutcome(log: contactLog, outcome: outcome)

--- a/FiveCalls/FiveCalls/Store.swift
+++ b/FiveCalls/FiveCalls/Store.swift
@@ -43,9 +43,9 @@ class Store: ObservableObject {
             state.issueCallCounts[issueID] = count
         case let .SetDonateOn(donateOn):
             state.donateOn = donateOn
-        case let .SetIssueContactCompletion(issueID, contactID):
+        case let .SetIssueContactCompletion(issueID, contactOutcome):
             var existingCompletions = state.issueCompletion[issueID] ?? []
-            existingCompletions.append(contactID)
+            existingCompletions.append(contactOutcome)
             state.issueCompletion[issueID] = existingCompletions
         case let .SetFetchingContacts(fetching):
             state.fetchingContacts = fetching

--- a/FiveCalls/FiveCalls/Store.swift
+++ b/FiveCalls/FiveCalls/Store.swift
@@ -62,7 +62,7 @@ class Store: ObservableObject {
             state.issueLoadingError = error
         case let .SetLoadingContactsError(error):
             state.contactsLoadingError = error
-        case .FetchStats, .FetchIssues, .FetchContacts(_), .ReportOutcome(_, _):
+        case .FetchStats, .FetchIssues, .FetchContacts(_), .ReportOutcome(_, _, _):
             // handled in middleware
             break
         }


### PR DESCRIPTION
Fixes #387 

Changed the local issue completion cache to store `B0001234-contact` rather than just the contact id so we can see what the most recent results were. This works well enough but I would note that it is incorrect when you have called on a topic in the past and entered a valid result, like contact, but then skip that contact the next time. In the current implementation it'll fetch the most recent contact result, since skip is the absence of an entry in that list. I don't think this is an issue, I would prefer to keep the assumption in the codebase that skip is an absence of a contact outcome vs changing it to a skip outcome.

`Package.resolved` is back. Not sure when it was removed last?