### PR TITLE
Handle deeplinks, move to swiftui-native main

### DIFF
--- a/FiveCalls/FiveCalls/App.swift
+++ b/FiveCalls/FiveCalls/App.swift
@@ -14,18 +14,18 @@ struct FiveCallsApp: App {
             
     let store = Store(state: AppState(), middlewares: [appMiddleware()])
     @AppStorage(UserDefaultsKey.hasShownWelcomeScreen.rawValue) var hasShownWelcomeScreen = false
-    @State var welcomePresented = false
+    @State var showWelcomeScreen = false
 
     var body: some Scene {
         WindowGroup {
             IssueSplitView()
                 .environmentObject(store)
-                .sheet(isPresented: $welcomePresented) {
+                .sheet(isPresented: $showWelcomeScreen) {
                     Welcome().environmentObject(store)
                 }
                 .onAppear {
                     if !hasShownWelcomeScreen {
-                        welcomePresented = true
+                        showWelcomeScreen = true
                         hasShownWelcomeScreen = true
                     }
                 }

--- a/FiveCalls/FiveCalls/App.swift
+++ b/FiveCalls/FiveCalls/App.swift
@@ -8,14 +8,28 @@
 
 import SwiftUI
 
-//@main // TODO: once SwiftUI is done move main here
-//struct FiveCallsApp: App {
-//    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-//            
-//    var body: some Scene {
-//        WindowGroup {
-//            Dashboard().environmentObject(appDelegate.appState)
-//        }
-//    }
-//}
+@main
+struct FiveCallsApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+            
+    let store = Store(state: AppState(), middlewares: [appMiddleware()])
+    @AppStorage(UserDefaultsKey.hasShownWelcomeScreen.rawValue) var hasShownWelcomeScreen = false
+    @State var welcomePresented = false
+
+    var body: some Scene {
+        WindowGroup {
+            IssueSplitView()
+                .environmentObject(store)
+                .sheet(isPresented: $welcomePresented) {
+                    Welcome().environmentObject(store)
+                }
+                .onAppear {
+                    if !hasShownWelcomeScreen {
+                        welcomePresented = true
+                        hasShownWelcomeScreen = true
+                    }
+                }
+        }
+    }
+}
 

--- a/FiveCalls/FiveCalls/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppDelegate.swift
@@ -11,12 +11,7 @@ import SwiftUI
 import OneSignal
 import TipKit
 
-@UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
-    
-    var appState = AppState()
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         if isUITesting() {
@@ -31,22 +26,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         oneSignalStartup(launchOptions: launchOptions)
         OneSignal.setExternalUserId(AnalyticsManager.shared.callerID)
         
-        window = UIWindow()
-
-        let store = Store(state: AppState(), middlewares: [appMiddleware()])
-        window?.rootViewController = UIHostingController(rootView: IssueSplitView()
-            .environmentObject(store))
-        
         if #available(iOS 17.0, *) {
             try? Tips.configure()
         }
-            
-        if !UserDefaults.standard.bool(forKey: UserDefaultsKey.hasShownWelcomeScreen.rawValue) {
-            showWelcome(store: store)
-        }
-
-        window?.makeKeyAndVisible()
-        
+                    
         return true
     }
 
@@ -55,9 +38,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             let incomingURL = userActivity.webpageURL else {
             return false
         }
-        // sets a string like 'usps-postal-service-covid-funding' that we can use when issues are loaded
-        UserDefaults.standard.set(incomingURL.lastPathComponent, forKey: UserDefaultsKey.selectIssuePath.rawValue)
-
+        
         return true
     }
     
@@ -66,33 +47,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             OneSignal.initWithLaunchOptions(launchOptions)
             OneSignal.setAppId(oneSignalAppID)
         }
-    }
-    
-    func transitionTo(rootViewController viewController: UIViewController) {
-        guard let window = self.window else { return }
-        guard window.rootViewController != viewController else { return }
-        
-        let snapshot = window.snapshotView(afterScreenUpdates: false)!
-        viewController.view.addSubview(snapshot)
-        window.rootViewController = viewController
-        
-        UIView.animate(withDuration: 0.5, animations: {
-            snapshot.alpha = 0
-            snapshot.frame.origin.y += window.frame.size.height
-            snapshot.transform = snapshot.transform.scaledBy(x: 0.8, y: 0.8)
-        }) { completed in
-            snapshot.removeFromSuperview()
-        }
-    }
-        
-    func showWelcome(store: Store) {
-        guard let window = self.window else { return }
-        let mainVC = window.rootViewController!
-        let welcomeVC = UIHostingController(rootView: Welcome(onContinue: {
-            UserDefaults.standard.set(true, forKey: UserDefaultsKey.hasShownWelcomeScreen.rawValue)
-            self.transitionTo(rootViewController: mainVC)
-        }).environmentObject(store))
-        window.rootViewController = welcomeVC
     }
     
     func setAppearance() {
@@ -134,7 +88,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func clearNotificationBadge() {
         UIApplication.shared.applicationIconBadgeNumber = 0
     }
-
 
     private func resetOrInitializeCountForRating() {
         let defaults = UserDefaults.standard

--- a/FiveCalls/FiveCalls/AppState.swift
+++ b/FiveCalls/FiveCalls/AppState.swift
@@ -24,7 +24,11 @@ class AppState: ObservableObject, ReduxState {
         }
     }
     @Published var donateOn = false
-    @Published var issues: [Issue] = []
+    @Published var issues: [Issue] = [] {
+        didSet {
+            issueLoadedCallback?()
+        }
+    }
     @Published var contacts: [Contact] = []
     @Published var location: NewUserLocation? {
         didSet {
@@ -43,6 +47,8 @@ class AppState: ObservableObject, ReduxState {
     @Published var issueLoadingError: Error? = nil
     // TODO: display this error on the dashboard (and location sheet?)
     @Published var contactsLoadingError: Error? = nil
+    
+    var issueLoadedCallback: (() -> Void)?
 
     init() {
         // load user location cache

--- a/FiveCalls/FiveCalls/Dashboard.swift
+++ b/FiveCalls/FiveCalls/Dashboard.swift
@@ -60,6 +60,24 @@ struct Dashboard: View {
                 store.dispatch(action: .FetchContacts(location))
             }
         }
+        .onOpenURL(perform: { url in
+            if store.state.issues.isEmpty {
+                store.state.issueLoadedCallback = {
+                    selectIssue(fromURL: url)
+                    store.state.issueLoadedCallback = nil
+                }
+            } else {
+                selectIssue(fromURL: url)
+            }
+        })
+    }
+    
+    func selectIssue(fromURL url: URL) {
+        store.state.issues.forEach { issue in
+            if issue.slug == url.lastPathComponent {
+                selectedIssue = issue
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Handles deeplinks from the site, adopting the new `.onOpenURL` syntax in SwiftUI required a move to the SwiftUI-native Scene + WindowGroup creation in `App.swift`.

These changes introduce a bug between tipkit and the welcome screen: #393. There were already enough changes here that I didn't want to start messing with how tipkit is presented here.

Fixes #388 