### PR TITLE
Update phone number call/copy a11y

### DIFF
--- a/FiveCalls/FiveCalls/IssueContactDetail.swift
+++ b/FiveCalls/FiveCalls/IssueContactDetail.swift
@@ -92,20 +92,16 @@ struct IssueContactDetail: View {
                         if currentContact.fieldOffices.count > 1 {
                             Menu {
                                 ForEach(currentContact.fieldOffices) { office in
-                                    Section {
-                                        Text(office.city)
-                                    }
-                                    
                                     ControlGroup {
                                         Button {
                                             self.call(phoneNumber: office.phone)
                                         } label: {
                                             HStack {
                                                 Image(systemName: "phone")
-                                                Text(office.phone)
+                                                Text(office.city)
                                             }
                                         }
-                                        .accessibilityLabel(R.string.localizable.a11yCallPhoneNumber(office.phone))
+                                        .accessibilityLabel(R.string.localizable.a11yOfficeCallPhoneNumber(office.city, office.phone))
                                         .accessibilityHint(R.string.localizable.a11yPhoneCallHint())
                                         
                                         Button {
@@ -129,7 +125,7 @@ struct IssueContactDetail: View {
                                                 Text(R.string.localizable.copy())
                                             }
                                         }
-                                        .accessibilityLabel(R.string.localizable.a11yCopyPhoneNumber(office.phone))
+                                        .accessibilityLabel(R.string.localizable.a11yOfficeCopyPhoneNumber(office.city, office.phone))
                                         .accessibilityHint(R.string.localizable.a11yPhoneCopyHint())
                                     }
                                 }

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -96,8 +96,8 @@
 "a11y-phone-call-hint"                = "Double tap to call";
 "a11y-phone-copy-hint"                = "Triple tap to copy";
 "a11y-copied-phone-number"            = "Copied phone number";
-"a11y-call-phone-number"              = "Call %@";
-"a11y-copy-phone-number"              = "Copy %@";
+"a11y-office-call-phone-number"       = "Call %@ %@";
+"a11y-office-copy-phone-number"       = "Copy %@ %@";
 "copied-phone"                        = "Copied\n%@!";
 "copy"                                = "Copy";
 


### PR DESCRIPTION
Per @heathermh's suggestion [here](https://github.com/5calls/ios/pull/397#issuecomment-1867124852), I moved the office section to the call button and added office name to accessibility labels for clarity.
https://github.com/5calls/ios/assets/810263/928f3b06-c8f2-4fd9-9c0c-ce084dd82366

