### PR TITLE
Set launch screen BG on dark mode

### DIFF
--- a/FiveCalls/FiveCalls/Base.lproj/LaunchScreen.storyboard
+++ b/FiveCalls/FiveCalls/Base.lproj/LaunchScreen.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -27,7 +28,7 @@
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" name="launchScreenBG"/>
                         <constraints>
                             <constraint firstItem="UTy-pW-PAa" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="BmV-7A-7fG"/>
                             <constraint firstItem="UTy-pW-PAa" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="JUx-Fp-Lim"/>
@@ -41,5 +42,8 @@
     </scenes>
     <resources>
         <image name="stars-blue" width="250" height="250"/>
+        <namedColor name="launchScreenBG">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </namedColor>
     </resources>
 </document>

--- a/FiveCalls/FiveCalls/Colors.xcassets/launchScreenBG.colorset/Contents.json
+++ b/FiveCalls/FiveCalls/Colors.xcassets/launchScreenBG.colorset/Contents.json
@@ -1,0 +1,34 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "gray-gamma-22",
+        "components" : {
+          "alpha" : "1.000",
+          "white" : "255"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "gray-gamma-22",
+        "components" : {
+          "alpha" : "1.000",
+          "white" : "0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
Looks great without adjusting the star color

<img width="347" alt="Screenshot 2023-12-29 at 10 20 00 PM" src="https://github.com/5calls/ios/assets/49688/33466821-3b12-4371-9fdc-63b4401cb803">

Fixes #401 