### PR TITLE
Set callerid header on all operations

### DIFF
--- a/FiveCalls/FiveCalls/BaseOperation.swift
+++ b/FiveCalls/FiveCalls/BaseOperation.swift
@@ -41,6 +41,12 @@ class BaseOperation : Operation {
         return _finished
     }
     
+    func buildRequest(forURL url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.setValue(AnalyticsManager.shared.callerID, forHTTPHeaderField: "X-Caller-ID")
+        return request
+    }
+    
     override func start() {
         _executing = true
         execute()

--- a/FiveCalls/FiveCalls/FetchContactsOperation.swift
+++ b/FiveCalls/FiveCalls/FetchContactsOperation.swift
@@ -40,20 +40,17 @@ class FetchContactsOperation : BaseOperation {
         }
     }
     
-    private func buildURL() -> URL? {
+    var url: URL {
         var components = URLComponents(string: "https://api.5calls.org/v1/reps")
         let locationQueryParam = URLQueryItem(name: "location", value: location.locationValue ?? "")
         components?.queryItems = [locationQueryParam]
-        return components?.url
+        return components!.url!
     }
     
     override func execute() {
-        guard let url = buildURL() else {
-            finish()
-            return
-        }
+        let request = buildRequest(forURL: url)
         
-        let task = session.dataTask(with: url) { data, response, error in
+        let task = session.dataTask(with: request) { data, response, error in
             if let e = error {
                self.error = e
             } else {
@@ -61,7 +58,6 @@ class FetchContactsOperation : BaseOperation {
             }
             self.finish()
         }
-        print("Fetching reps...\(url)")
         task.resume()
     }
     

--- a/FiveCalls/FiveCalls/FetchIssuesOperation.swift
+++ b/FiveCalls/FiveCalls/FetchIssuesOperation.swift
@@ -29,13 +29,14 @@ class FetchIssuesOperation : BaseOperation {
         }
     }
     
-    func buildIssuesURL() -> URL {
+    var url: URL {
         return URL(string: "https://api.5calls.org/v1/issues?includeHidden=true")!
     }
 
     override func execute() {
-        let url = buildIssuesURL()
-        let task = session.dataTask(with: url) { (data, response, error) in
+        let request = buildRequest(forURL: url)
+        
+        let task = session.dataTask(with: request) { (data, response, error) in
             if let e = error {
                 print("Error fetching issues: \(e.localizedDescription)")
                 self.error = e
@@ -45,7 +46,7 @@ class FetchIssuesOperation : BaseOperation {
             
             self.finish()
         }
-        print("Fetching issues...\(url)")
+
         task.resume()
     }
     

--- a/FiveCalls/FiveCalls/FetchStatsOperation.swift
+++ b/FiveCalls/FiveCalls/FetchStatsOperation.swift
@@ -29,15 +29,21 @@ class FetchStatsOperation: BaseOperation {
             self.session = URLSession(configuration: config)
         }
     }
-
-    override func execute() {
+    
+    var url: URL {
         var urlComp = URLComponents(url: URL(string: "https://api.5calls.org/v1/report")!, resolvingAgainstBaseURL: false)!
         if let issueID = self.issueID {
             let issueIDQuery = URLQueryItem(name: "issueID", value: issueID)
             urlComp.queryItems = [issueIDQuery]
         }
         
-        let task = session.dataTask(with: urlComp.url!) { (data, response, error) in
+        return urlComp.url!
+    }
+
+    override func execute() {
+        let request = buildRequest(forURL: url)
+        
+        let task = session.dataTask(with: request) { (data, response, error) in
             if let e = error {
                 self.error = e
             } else {

--- a/FiveCalls/FiveCalls/FetchUserStatsOperation.swift
+++ b/FiveCalls/FiveCalls/FetchUserStatsOperation.swift
@@ -19,14 +19,15 @@ class FetchUserStatsOperation : BaseOperation {
     
     private var retryCount = 0
     
+    var url: URL {
+        return URL(string: "https://api.5calls.org/v1/users/stats")!
+    }
+    
     override func execute() {
         let config = URLSessionConfiguration.default
         let session = URLSession(configuration: config)
-        let url = URL(string: "https://api.5calls.org/v1/users/stats")!
 
-        var request = URLRequest(url: url)
-        request.setValue(AnalyticsManager.shared.callerID, forHTTPHeaderField: "X-Caller-ID")
-
+        var request = buildRequest(forURL: url)
         let task = session.dataTask(with: request) { (data, response, error) in
             
             if let e = error {

--- a/FiveCalls/FiveCalls/ReportOutcomeOperation.swift
+++ b/FiveCalls/FiveCalls/ReportOutcomeOperation.swift
@@ -22,11 +22,14 @@ class ReportOutcomeOperation : BaseOperation {
         self.log = log
         self.outcome = outcome
     }
+    
+    var url: URL {
+        return URL(string: "https://api.5calls.org/v1/report")!
+    }
 
     override func execute() {
         let config = URLSessionConfiguration.default
         let session = URLSession(configuration: config)
-        let url = URL(string: "https://api.5calls.org/v1/report")!
 
         // rather than avoiding network calls during debug,
         // indicate they shouldn't be included in counts
@@ -37,10 +40,9 @@ class ReportOutcomeOperation : BaseOperation {
             via = "ios"
         #endif
 
-        var request = URLRequest(url: url)
+        var request = buildRequest(forURL: url)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        request.setValue(AnalyticsManager.shared.callerID, forHTTPHeaderField: "X-Caller-ID")
 
         let query = "result=\(outcome.label)&contactid=\(log.contactId)&issueid=\(log.issueId)&phone=\(log.phone)&via=\(via)&callerid=\(AnalyticsManager.shared.callerID)"
         guard let data = query.data(using: .utf8) else {


### PR DESCRIPTION
Standardize how we generate urls and requests in operations, always set the callerid as a header value in requests.

Fixes #409