### PR TITLE
Ensure welcome screen shown before menu popover tip

### DIFF
--- a/FiveCalls/FiveCalls/Actions.swift
+++ b/FiveCalls/FiveCalls/Actions.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum Action {
+    case ShowWelcomeScreen
     case FetchStats(Int?)
     case SetGlobalCallCount(Int)
     case SetIssueCallCount(Int,Int)

--- a/FiveCalls/FiveCalls/App.swift
+++ b/FiveCalls/FiveCalls/App.swift
@@ -10,23 +10,21 @@ import SwiftUI
 
 @main
 struct FiveCallsApp: App {
+    @StateObject var store: Store = Store(state: AppState(), middlewares: [appMiddleware()])
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
             
-    let store = Store(state: AppState(), middlewares: [appMiddleware()])
     @AppStorage(UserDefaultsKey.hasShownWelcomeScreen.rawValue) var hasShownWelcomeScreen = false
-    @State var showWelcomeScreen = false
 
     var body: some Scene {
         WindowGroup {
             IssueSplitView()
                 .environmentObject(store)
-                .sheet(isPresented: $showWelcomeScreen) {
+                .sheet(isPresented: $store.state.showWelcomeScreen) {
                     Welcome().environmentObject(store)
                 }
                 .onAppear {
                     if !hasShownWelcomeScreen {
-                        showWelcomeScreen = true
-                        hasShownWelcomeScreen = true
+                        store.dispatch(action: .ShowWelcomeScreen)
                     }
                 }
         }

--- a/FiveCalls/FiveCalls/AppState.swift
+++ b/FiveCalls/FiveCalls/AppState.swift
@@ -11,6 +11,7 @@ import CoreLocation
 import os
 
 class AppState: ObservableObject, ReduxState {
+    @Published var showWelcomeScreen = false
     @Published var globalCallCount: Int = 0
     @Published var issueCallCounts: [Int: Int] = [:]
     // issueCompletion is a local cache of completed calls: an array of contact id and outcomes (B0001234-contact) keyed by an issue id

--- a/FiveCalls/FiveCalls/Dashboard.swift
+++ b/FiveCalls/FiveCalls/Dashboard.swift
@@ -20,7 +20,7 @@ struct Dashboard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                MenuView()
+                MenuView(showingWelcomeScreen: store.state.showWelcomeScreen)
 
                 LocationHeader(location: store.state.location, fetchingContacts: store.state.fetchingContacts)
                     .padding(.bottom, 10)
@@ -104,6 +104,7 @@ struct MenuView: View {
     @State var showRemindersSheet = false
     @State var showYourImpact = false
     @State var showAboutSheet = false
+    var showingWelcomeScreen: Bool
 
     var body: some View {
         Menu {
@@ -124,6 +125,7 @@ struct MenuView: View {
                 .accessibilityLabel(Text(R.string.localizable.menuName))
         }
         .popoverTipIfApplicable(
+            showingWelcomeScreen: showingWelcomeScreen,
             title: Text(R.string.localizable.menuTipTitle()),
             message: Text(R.string.localizable.menuTipMessage()))
         .sheet(isPresented: $showRemindersSheet) {

--- a/FiveCalls/FiveCalls/Middleware.swift
+++ b/FiveCalls/FiveCalls/Middleware.swift
@@ -26,8 +26,9 @@ func appMiddleware() -> Middleware<AppState> {
             }
             AnalyticsManager.shared.trackEvent(name: "Outcome-\(outcome.status)", path: "/issues/\(issue.slug)/")
             reportOutcome(log: contactLog, outcome: outcome)
-        case .SetGlobalCallCount, .SetIssueCallCount, .SetDonateOn, .SetIssueContactCompletion, .SetContacts, .SetFetchingContacts, .SetIssues,
-                .SetLoadingStatsError, .SetLoadingIssuesError, .SetLoadingContactsError, .GoBack, .GoToRoot, .GoToNext:
+        case .SetGlobalCallCount, .SetIssueCallCount, .SetDonateOn, .SetIssueContactCompletion, .SetContacts, 
+                .SetFetchingContacts, .SetIssues, .SetLoadingStatsError, .SetLoadingIssuesError, .SetLoadingContactsError,
+                .GoBack, .GoToRoot, .GoToNext, .ShowWelcomeScreen:
             // no middleware actions for these, including for completeness
             break
         }

--- a/FiveCalls/FiveCalls/PopoverTip.swift
+++ b/FiveCalls/FiveCalls/PopoverTip.swift
@@ -21,18 +21,26 @@ struct PopoverTip: Tip {
 }
 
 extension View {
-    func popoverTipIfApplicable(title: Text, message: Text?) -> some View {
-    if #available(iOS 17, *) {
-        return self
-            .popoverTip(
-                PopoverTip(
-                    title: title,
-                    message: message
-                ),
-                arrowEdge: .top
-            )
-    } else {
-      return self
+    func popoverTipIfApplicable(showingWelcomeScreen: Bool,
+                                title: Text,
+                                message: Text?)
+        -> some View
+    {
+        if #available(iOS 17, *) {
+            if showingWelcomeScreen {
+                AnyView(self)
+            } else {
+                AnyView(self
+                    .popoverTip(
+                        PopoverTip(
+                            title: title,
+                            message: message
+                        ),
+                        arrowEdge: .top
+                    ))
+            }
+        } else {
+          AnyView(self)
+        }
     }
-  }
 }

--- a/FiveCalls/FiveCalls/Store.swift
+++ b/FiveCalls/FiveCalls/Store.swift
@@ -38,6 +38,8 @@ class Store: ObservableObject {
     func reduce(_ oldState: AppState, _ action: Action) -> AppState {
         let state = oldState
         switch action {
+        case .ShowWelcomeScreen:
+            state.showWelcomeScreen = true
         case let .SetGlobalCallCount(globalCallCount):
             state.globalCallCount = globalCallCount
         case let .SetIssueCallCount(issueID, count):

--- a/FiveCalls/FiveCalls/Welcome.swift
+++ b/FiveCalls/FiveCalls/Welcome.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct Welcome: View {
+    @AppStorage(UserDefaultsKey.hasShownWelcomeScreen.rawValue) var hasShownWelcomeScreen = false
+
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var store: Store
 
@@ -90,6 +92,7 @@ struct Welcome: View {
                 }
             }
             .onAppear() {
+                hasShownWelcomeScreen = true
                 if store.state.globalCallCount == 0 {
                     store.dispatch(action: .FetchStats(nil))
                 }


### PR DESCRIPTION
Fixes the issue where menu popover tip prevents welcome screen from showing first time app is opened.

https://github.com/5calls/ios/assets/810263/c8426e49-70fb-4fae-920e-b06140eadca5

**Note:**
In this fix, we do not show the menu popover tip the first time the app is launched if the welcome screen is shown, but it will be shown subsequent app launches. I had another implementation that showed the tooltip after the welcome screen is shown, but it was buggy and often was delayed and sometimes even showed up on the detail screen when the menu isn't even available.