### PR TITLE
Move the navigation link into the outcome grid

### DIFF
--- a/FiveCalls/FiveCalls/IssueContactDetail.swift
+++ b/FiveCalls/FiveCalls/IssueContactDetail.swift
@@ -142,22 +142,18 @@ struct IssueContactDetail: View {
                     .padding(.bottom)
                 
                 if remainingContacts.count > 1 {
-                    NavigationLink(value: IssueDetailNavModel(issue: issue, contacts: nextContacts)) {
-                        OutcomesView(outcomes: issue.outcomeModels, report: { outcome in
-                            let log = ContactLog(issueId: String(issue.id), contactId: currentContact.id, phone: "", outcome: outcome.status, date: Date(), reported: true)
-                            store.dispatch(action: .ReportOutcome(issue, log, outcome))
-                            store.dispatch(action: .GoToNext(issue, nextContacts))
-                        })
-                    }
+                    OutcomesView(outcomes: issue.outcomeModels, navModel: IssueDetailNavModel(issue: issue, contacts: nextContacts), report: { outcome in
+                        let log = ContactLog(issueId: String(issue.id), contactId: currentContact.id, phone: "", outcome: outcome.status, date: Date(), reported: true)
+                        store.dispatch(action: .ReportOutcome(issue, log, outcome))
+                        store.dispatch(action: .GoToNext(issue, nextContacts))
+                    })
                 } else {
-                    NavigationLink(value: IssueNavModel(issue: issue, type: "done")) {
-                        OutcomesView(outcomes: issue.outcomeModels, report:
-                            { outcome in
-                            let log = ContactLog(issueId: String(issue.id), contactId: currentContact.id, phone: "", outcome: outcome.status, date: Date(), reported: true)
-                            store.dispatch(action: .ReportOutcome(issue, log, outcome))
-                            store.dispatch(action: .GoToNext(issue, []))
-                        })
-                    }
+                    OutcomesView(outcomes: issue.outcomeModels, navModel: IssueNavModel(issue: issue, type: "done"), report:
+                        { outcome in
+                        let log = ContactLog(issueId: String(issue.id), contactId: currentContact.id, phone: "", outcome: outcome.status, date: Date(), reported: true)
+                        store.dispatch(action: .ReportOutcome(issue, log, outcome))
+                        store.dispatch(action: .GoToNext(issue, []))
+                    })
                 }
                 Spacer()
             }.padding(.horizontal)

--- a/FiveCalls/FiveCalls/IssueContactDetail.swift
+++ b/FiveCalls/FiveCalls/IssueContactDetail.swift
@@ -142,13 +142,13 @@ struct IssueContactDetail: View {
                     .padding(.bottom)
                 
                 if remainingContacts.count > 1 {
-                    OutcomesView(outcomes: issue.outcomeModels, navModel: IssueDetailNavModel(issue: issue, contacts: nextContacts), report: { outcome in
+                    OutcomesView<IssueDetailNavModel>(outcomes: issue.outcomeModels, navModel: IssueDetailNavModel(issue: issue, contacts: nextContacts), report: { outcome in
                         let log = ContactLog(issueId: String(issue.id), contactId: currentContact.id, phone: "", outcome: outcome.status, date: Date(), reported: true)
                         store.dispatch(action: .ReportOutcome(issue, log, outcome))
                         store.dispatch(action: .GoToNext(issue, nextContacts))
                     })
                 } else {
-                    OutcomesView(outcomes: issue.outcomeModels, navModel: IssueNavModel(issue: issue, type: "done"), report:
+                    OutcomesView<IssueNavModel>(outcomes: issue.outcomeModels, navModel: IssueNavModel(issue: issue, type: "done"), report:
                         { outcome in
                         let log = ContactLog(issueId: String(issue.id), contactId: currentContact.id, phone: "", outcome: outcome.status, date: Date(), reported: true)
                         store.dispatch(action: .ReportOutcome(issue, log, outcome))

--- a/FiveCalls/FiveCalls/OutcomesView.swift
+++ b/FiveCalls/FiveCalls/OutcomesView.swift
@@ -8,9 +8,9 @@
 
 import SwiftUI
 
-struct OutcomesView: View {
+struct OutcomesView<T: Hashable>: View {
     let outcomes: [Outcome]
-    let navModel: AnyHashable
+    let navModel: T
     let report: (Outcome) -> ()
     
     var body: some View {

--- a/FiveCalls/FiveCalls/OutcomesView.swift
+++ b/FiveCalls/FiveCalls/OutcomesView.swift
@@ -10,23 +10,25 @@ import SwiftUI
 
 struct OutcomesView: View {
     let outcomes: [Outcome]
+    let navModel: AnyHashable
     let report: (Outcome) -> ()
     
     var body: some View {
         LazyVGrid(columns: [GridItem(.flexible()),GridItem(.flexible())]) {
             ForEach(outcomes) { outcome in
-                PrimaryButton(title: outcome.label.capitalized,
-                              systemImageName: "megaphone.fill")
+                NavigationLink(value: navModel) {
+                    PrimaryButton(title: outcome.label.capitalized,
+                                  systemImageName: "megaphone.fill")
                     .onTapGesture {
                         report(outcome)
                     }
+                }
             }
         }
-
     }
 }
 
 #Preview {
-    OutcomesView(outcomes: [Outcome(label: "OK", status: "ok"),Outcome(label: "No", status: "no"),Outcome(label: "Maybe", status: "maybe")], report: { _ in })
+    OutcomesView(outcomes: [Outcome(label: "OK", status: "ok"),Outcome(label: "No", status: "no"),Outcome(label: "Maybe", status: "maybe")], navModel: IssueNavModel(issue: .basicPreviewIssue, type: "mock"), report: { _ in })
         .padding()
 }


### PR DESCRIPTION
Looks like having a single nav link over a bunch of buttons was confusing VoiceOver. Making a nav link for each outcome button makes each button show in VoiceOver as expected.

Fixes #413 