### PR TITLE
Enable code coverage to encourage eventual complete code coverage

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/xcshareddata/xcschemes/FiveCalls.xcscheme
+++ b/FiveCalls/FiveCalls.xcodeproj/xcshareddata/xcschemes/FiveCalls.xcscheme
@@ -40,7 +40,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -50,6 +52,15 @@
             ReferencedContainer = "container:FiveCalls.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B52805101E3FA94D00EE832A"
+            BuildableName = "FiveCalls.app"
+            BlueprintName = "FiveCalls"
+            ReferencedContainer = "container:FiveCalls.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Enable built-in code coverage in Xcode to encourage code coverage completion progress.

![Screenshot 2024-01-05 at 11 08 02 AM](https://github.com/5calls/ios/assets/810263/ece3d107-fc40-4aeb-8089-2540c393bea0)
