### PR TITLE
add code coverage to fastlane

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ gem "cocoapods-acknowledgements"
 gem "dotenv"
 gem "fastlane"
 gem "badge"
-
+gem "xcov"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,6 +23,16 @@ platform :ios do
     scan(project: xcodeproj, scheme: scheme, xcargs: "-skipPackagePluginValidation")
   end
 
+  desc "Runs code coverage"
+  lane :coverage do
+    clear_derived_data(derived_data_path: "xcov_output")
+    scan(project: xcodeproj, scheme: scheme, xcargs: "-skipPackagePluginValidation")
+    xcov(project: "FiveCalls/FiveCalls.xcodeproj",
+    scheme: "FiveCalls",
+    minimum_coverage_percentage: 24.0,
+    output_directory: "xcov_output")
+  end
+
   desc "Increments build number"
   lane :increment_build do
     increment_build_number(xcodeproj: xcodeproj)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,12 +21,9 @@ platform :ios do
   desc "Runs all the tests"
   lane :test do
     scan(project: xcodeproj, scheme: scheme, xcargs: "-skipPackagePluginValidation")
-    xcov(project: "FiveCalls/FiveCalls.xcodeproj",
-    scheme: "FiveCalls",
-    minimum_coverage_percentage: 25.0)
   end
 
-  desc "Runs code coverage"
+  desc "Runs code coverage (requires running tests first)"
   lane :coverage do
     xcov(project: "FiveCalls/FiveCalls.xcodeproj",
     scheme: "FiveCalls",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,16 +23,14 @@ platform :ios do
     scan(project: xcodeproj, scheme: scheme, xcargs: "-skipPackagePluginValidation")
     xcov(project: "FiveCalls/FiveCalls.xcodeproj",
     scheme: "FiveCalls",
-    minimum_coverage_percentage: 30.0)
+    minimum_coverage_percentage: 25.0)
   end
 
   desc "Runs code coverage"
   lane :coverage do
-    clear_derived_data(derived_data_path: "xcov_output")
     xcov(project: "FiveCalls/FiveCalls.xcodeproj",
     scheme: "FiveCalls",
-    minimum_coverage_percentage: 24.0,
-    output_directory: "xcov_output")
+    minimum_coverage_percentage: 25.0)
   end
 
   desc "Increments build number"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,13 +20,17 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
+    clear_derived_data(derived_data_path: "xcov_output")
     scan(project: xcodeproj, scheme: scheme, xcargs: "-skipPackagePluginValidation")
+    xcov(project: "FiveCalls/FiveCalls.xcodeproj",
+    scheme: "FiveCalls",
+    minimum_coverage_percentage: 24.0,
+    output_directory: "xcov_output")
   end
 
   desc "Runs code coverage"
   lane :coverage do
     clear_derived_data(derived_data_path: "xcov_output")
-    scan(project: xcodeproj, scheme: scheme, xcargs: "-skipPackagePluginValidation")
     xcov(project: "FiveCalls/FiveCalls.xcodeproj",
     scheme: "FiveCalls",
     minimum_coverage_percentage: 24.0,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,12 +20,10 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
-    clear_derived_data(derived_data_path: "xcov_output")
     scan(project: xcodeproj, scheme: scheme, xcargs: "-skipPackagePluginValidation")
     xcov(project: "FiveCalls/FiveCalls.xcodeproj",
     scheme: "FiveCalls",
-    minimum_coverage_percentage: 24.0,
-    output_directory: "xcov_output")
+    minimum_coverage_percentage: 30.0)
   end
 
   desc "Runs code coverage"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -23,6 +23,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Runs all the tests
 
+### ios coverage
+
+```sh
+[bundle exec] fastlane ios coverage
+```
+
+Runs code coverage
+
 ### ios increment_build
 
 ```sh


### PR DESCRIPTION
Adds code coverage lane which can be used to ensure minimum coverage
<img width="980" alt="Screenshot 2024-01-11 at 9 58 21 AM" src="https://github.com/5calls/ios/assets/810263/23a81d02-4a4e-4211-b7c5-cc6d9e642bbb">
