### PR TITLE
Tweak contact's call/copy to adjust for AX text sizes

### DIFF
--- a/FiveCalls/FiveCalls/IssueContactDetail.swift
+++ b/FiveCalls/FiveCalls/IssueContactDetail.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct IssueContactDetail: View {
     @EnvironmentObject var store: Store
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     let issue: Issue
     let remainingContacts: [Contact]
@@ -95,7 +96,9 @@ struct IssueContactDetail: View {
                                         Button {
                                             self.call(phoneNumber: office.phone)
                                         } label: {
-                                            HStack {
+                                            if dynamicTypeSize >= .accessibility1 {
+                                                Text(R.string.localizable.a11yOfficeCallPhoneNumber(office.city, office.phone))
+                                            } else {
                                                 Image(systemName: "phone")
                                                 Text(office.city)
                                             }
@@ -119,7 +122,9 @@ struct IssueContactDetail: View {
                                                 }
                                             }
                                         } label: {
-                                            HStack {
+                                            if dynamicTypeSize >= .accessibility1 {
+                                                Text(R.string.localizable.a11yOfficeCopyPhoneNumber(office.city, office.phone))
+                                            } else {
                                                 Image(systemName: "doc.on.doc")
                                                 Text(R.string.localizable.copy())
                                             }


### PR DESCRIPTION
Menu formatting doesn't want to play nice. Added check for AX1 and larger text so we can make sure user knows they're calling vs copying the phone number

Checked animations and I think it's OK to leave them for now. They're minimal and hopefully not intrusive for folks who have reduce motion enabled.