### PR TITLE
Lighten blue text color in darkmode

### DIFF
--- a/FiveCalls/FiveCalls/Colors.xcassets/fivecallsDarkBlueText.colorset/Contents.json
+++ b/FiveCalls/FiveCalls/Colors.xcassets/fivecallsDarkBlueText.colorset/Contents.json
@@ -41,9 +41,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.820",
-          "green" : "0.460",
-          "red" : "0.090"
+          "blue" : "0xEC",
+          "green" : "0x99",
+          "red" : "0x46"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
Contrast ratios comparison, I increased the luminance of the blue until it passed all those WCAG AAA tests.

Fixes #435 

<img width="757" alt="Screenshot 2024-02-08 at 8 05 08 AM" src="https://github.com/5calls/ios/assets/49688/4abe4ce3-17b7-40da-b893-c9e4c0ca4528">
<img width="774" alt="Screenshot 2024-02-08 at 8 05 51 AM" src="https://github.com/5calls/ios/assets/49688/dbf5b326-4a57-4cc0-84a6-cae9945c11f3">
