### PR TITLE
Use the status localizations for outcome buttons

### DIFF
--- a/FiveCalls/FiveCalls/OutcomesView.swift
+++ b/FiveCalls/FiveCalls/OutcomesView.swift
@@ -15,7 +15,7 @@ struct OutcomesView: View {
     var body: some View {
         LazyVGrid(columns: [GridItem(.flexible()),GridItem(.flexible())]) {
             ForEach(outcomes) { outcome in
-                PrimaryButton(title: outcome.label.capitalized,
+                PrimaryButton(title: ContactLog.localizedOutcomeForStatus(status: outcome.status),
                                   systemImageName: "megaphone.fill")
                 .accessibilityAddTraits(.isButton)
                 .onTapGesture {


### PR DESCRIPTION
As you can see, pretty important to pair this with the button text size adjustment in #436 

Fixes #437 

<img width="456" alt="Screenshot 2024-02-08 at 8 15 39 AM" src="https://github.com/5calls/ios/assets/49688/d064f3e5-5fe1-4cc4-9d4d-0841ffa02b27">
