### PR TITLE
Remove button icons and padding so outcomes don't wrap

### DIFF
--- a/FiveCalls/FiveCalls/OutcomesView.swift
+++ b/FiveCalls/FiveCalls/OutcomesView.swift
@@ -15,8 +15,7 @@ struct OutcomesView: View {
     var body: some View {
         LazyVGrid(columns: [GridItem(.flexible()),GridItem(.flexible())]) {
             ForEach(outcomes) { outcome in
-                PrimaryButton(title: ContactLog.localizedOutcomeForStatus(status: outcome.status),
-                                  systemImageName: "megaphone.fill")
+                PrimaryButton(title: ContactLog.localizedOutcomeForStatus(status: outcome.status))
                 .accessibilityAddTraits(.isButton)
                 .onTapGesture {
                     report(outcome)
@@ -27,5 +26,6 @@ struct OutcomesView: View {
 }
 
 #Preview {
-    OutcomesView(outcomes: [Outcome(label: "OK", status: "ok"),Outcome(label: "No", status: "no"),Outcome(label: "Maybe", status: "maybe")], report: { _ in })
+    OutcomesView(outcomes: [Outcome(label: "Left Voicemail", status: "vm"),Outcome(label: "No", status: "no"),Outcome(label: "Maybe", status: "maybe")], report: { _ in })
+        .padding()
 }

--- a/FiveCalls/FiveCalls/PrimaryButton.swift
+++ b/FiveCalls/FiveCalls/PrimaryButton.swift
@@ -10,21 +10,24 @@ import SwiftUI
 
 struct PrimaryButton: View {
     let title: String
-    let systemImageName: String
+    var systemImageName: String? = ""
     
     var bgColor: Color = .fivecallsDarkBlue
-    
+        
     var body: some View {
         HStack {
             Text(title)
                 .font(.title3)
                 .fontWeight(.semibold)
                 .foregroundColor(.white)
-            Image(systemName: systemImageName)
-                .foregroundColor(.white)
+                .lineLimit(1)
+            if let systemImageName {
+                Image(systemName: systemImageName)
+                    .foregroundColor(.white)
+            }
         }
         .accessibilityElement(children: .combine)
-        .padding()
+        .padding(.vertical)
         .frame(maxWidth: .infinity)
         .background {
             RoundedRectangle(cornerRadius: 6)
@@ -33,9 +36,11 @@ struct PrimaryButton: View {
     }
 }
 
-struct PrimaryButton_Previews: PreviewProvider {
-    static var previews: some View {
+#Preview {
+    VStack {
         PrimaryButton(title: "See your script", systemImageName: "megaphone.fill")
-            .padding()
+                .padding()
+        PrimaryButton(title: "See your script")
+            .padding(.horizontal, 100)
     }
 }


### PR DESCRIPTION
I tried using `.minimumScaleFactor` here to reduce text size when it's too large which was great but I couldn't figure out how to match that size across all buttons, which is the design I would want to see for it.

Instead, just remove some icons and padding so it fits on small screens.

Fixes #436 

Previously:
<img width="456" alt="303403604-d064f3e5-5fe1-4cc4-9d4d-0841ffa02b27" src="https://github.com/5calls/ios/assets/49688/b1287d5e-4453-43b6-bc90-2add7c7c5271">


fixed:
<img width="432" alt="Screenshot 2024-02-11 at 8 28 55 AM" src="https://github.com/5calls/ios/assets/49688/57939c14-0645-4b14-bb7a-7e5bd71c8cb9">
