### PR TITLE
Remove ControlGroup < iOS 16.4 to fix area office numbers

### DIFF
--- a/FiveCalls/FiveCalls/PrimaryButton.swift
+++ b/FiveCalls/FiveCalls/PrimaryButton.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct PrimaryButton: View {
     let title: String
-    var systemImageName: String? = ""
+    var systemImageName: String?
     
     var bgColor: Color = .fivecallsDarkBlue
         


### PR DESCRIPTION
While debugging I noticed that if `ControlGroup` was used at all within `Menu` it wouldn't render anything inside of it so I refactored to remove it for iOS < 16.4 since we know its broken on 16.2 and I don't have 16.3 to test. I ensured VoiceOver still works including setting focus to copied text (at least on my device iOS 17.2.1 but it should work as well as before with the new UI <16.4).

|>= iOS 16.4 (no change)|< iOS 16.4|
|-|-|
|![IMG_2782](https://github.com/5calls/ios/assets/810263/a257dab1-55be-423a-a42a-a7784fbab9d7)|![Simulator Screenshot - iPhone 12 - 2024-02-25 at 07 25 05](https://github.com/5calls/ios/assets/810263/ae2787a5-01ff-4223-8beb-99512a746a41)|