### PR TITLE
Configurable calling group id

### DIFF
--- a/FiveCalls/FiveCalls/AboutSheet.swift
+++ b/FiveCalls/FiveCalls/AboutSheet.swift
@@ -69,7 +69,11 @@ struct AboutSheet: View {
                 Section {
                     TextField(R.string.localizable.aboutCallingGroupPlaceholder(), text: $callingGroup)
                         .onChange(of: callingGroup) { newValue in
-                            UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.callingGroup.rawValue)
+                            let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+                            if trimmed != newValue {
+                                callingGroup = trimmed
+                            }
+                            UserDefaults.standard.set(trimmed, forKey: UserDefaultsKey.callingGroup.rawValue)
                         }
                 } header: {
                     Text(R.string.localizable.aboutCallingGroupHeader().uppercased())

--- a/FiveCalls/FiveCalls/AboutSheet.swift
+++ b/FiveCalls/FiveCalls/AboutSheet.swift
@@ -19,6 +19,7 @@ struct AboutSheet: View {
     @State var showEmailComposer = false
     @State var showEmailComposerAlert = false
     @State var showWelcome = false
+    @State private var callingGroup: String = UserDefaults.standard.string(forKey: UserDefaultsKey.callingGroup.rawValue) ?? ""
     
     private var versionString: String? = {
         guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
@@ -36,14 +37,6 @@ struct AboutSheet: View {
                                   type: .webViewContent(WebViewContent.whycall))
                     AboutListItem(title: R.string.localizable.aboutItemWhoWeAre(), 
                                   type: .webViewContent(WebViewContent.whoweare))
-                    .navigationDestination(for: WebViewContent.self) { webViewContent in
-                        WebView(webViewContent: webViewContent)
-                            .navigationTitle(webViewContent.navigationTitle)
-                            .navigationBarTitleDisplayMode(.inline)
-                            .toolbarBackground(.visible)
-                            .toolbarBackground(Color.fivecallsDarkBlue)
-                            .toolbarColorScheme(.dark, for: .navigationBar)
-                    }
                     AboutListItem(title: R.string.localizable.aboutItemFeedback(),
                                   type: .action({
                         if EmailComposerView.canSendEmail() {
@@ -69,6 +62,21 @@ struct AboutSheet: View {
                     })
                 } header: {
                     Text(R.string.localizable.aboutSectionHeaderGeneral().uppercased())
+                        .font(.footnote)
+                        .foregroundStyle(.fivecallsDarkGray)
+                }
+
+                Section {
+                    TextField(R.string.localizable.aboutCallingGroupPlaceholder(), text: $callingGroup)
+                        .onChange(of: callingGroup) { newValue in
+                            UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.callingGroup.rawValue)
+                        }
+                } header: {
+                    Text(R.string.localizable.aboutCallingGroupHeader().uppercased())
+                        .font(.footnote)
+                        .foregroundStyle(.fivecallsDarkGray)
+                } footer: {
+                    Text(R.string.localizable.aboutCallingGroupFooter())
                         .font(.footnote)
                         .foregroundStyle(.fivecallsDarkGray)
                 }
@@ -143,7 +151,15 @@ struct AboutSheet: View {
                             .bold()
                     }
                 }
+            }.navigationDestination(for: WebViewContent.self) { webViewContent in
+                WebView(webViewContent: webViewContent)
+                    .navigationTitle(webViewContent.navigationTitle)
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbarBackground(.visible)
+                    .toolbarBackground(Color.fivecallsDarkBlue)
+                    .toolbarColorScheme(.dark, for: .navigationBar)
             }
+
         }
         .accentColor(.white)
     }

--- a/FiveCalls/FiveCalls/FetchIssuesOperation.swift
+++ b/FiveCalls/FiveCalls/FetchIssuesOperation.swift
@@ -25,7 +25,17 @@ class FetchIssuesOperation: BaseOperation, @unchecked Sendable {
     }
     
     var url: URL {
-        return URL(string: "https://api.5calls.org/v1/issues?includeHidden=true")!
+        var urlComponents = URLComponents(string: "https://api.5calls.org/v1/issues")!
+        var queryItems = [URLQueryItem(name: "includeHidden", value: "true")]
+        
+        // Add calling group if it exists
+        if let callingGroup = UserDefaults.standard.string(forKey: UserDefaultsKey.callingGroup.rawValue),
+           !callingGroup.isEmpty {
+            queryItems.append(URLQueryItem(name: "group", value: callingGroup))
+        }
+        
+        urlComponents.queryItems = queryItems
+        return urlComponents.url!
     }
 
     override func execute() {

--- a/FiveCalls/FiveCalls/FetchStatsOperation.swift
+++ b/FiveCalls/FiveCalls/FetchStatsOperation.swift
@@ -26,13 +26,24 @@ class FetchStatsOperation: BaseOperation, @unchecked Sendable {
     }
     
     var url: URL {
-        var urlComp = URLComponents(url: URL(string: "https://api.5calls.org/v1/report")!, resolvingAgainstBaseURL: false)!
+        var urlComponents = URLComponents(url: URL(string: "https://api.5calls.org/v1/report")!, resolvingAgainstBaseURL: false)!
+        var queryItems: [URLQueryItem] = []
+        
         if let issueID = self.issueID {
-            let issueIDQuery = URLQueryItem(name: "issueID", value: issueID)
-            urlComp.queryItems = [issueIDQuery]
+            queryItems.append(URLQueryItem(name: "issueID", value: issueID))
         }
         
-        return urlComp.url!
+        // Add calling group if it exists
+        if let callingGroup = UserDefaults.standard.string(forKey: UserDefaultsKey.callingGroup.rawValue),
+           !callingGroup.isEmpty {
+            queryItems.append(URLQueryItem(name: "group", value: callingGroup))
+        }
+        
+        if !queryItems.isEmpty {
+            urlComponents.queryItems = queryItems
+        }
+        
+        return urlComponents.url!
     }
 
     override func execute() {

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -167,6 +167,9 @@
 "about-webview-title-why-call"        = "Why Calling Works";
 "about-webview-title-who-we-are"      = "Who Made 5 Calls";
 "about-acknowledgements-title"        = "Open Source";
+"about-callingGroup-header"           = "Calling Group";
+"about-callingGroup-placeholder"      = "Enter your calling group name";
+"about-callingGroup-footer"           = "Set a calling group name to track calls with others";
 
 // your impact
 "your-impact-title"                   = "My Impact";

--- a/FiveCalls/FiveCalls/ReportOutcomeOperation.swift
+++ b/FiveCalls/FiveCalls/ReportOutcomeOperation.swift
@@ -44,7 +44,22 @@ class ReportOutcomeOperation: BaseOperation, @unchecked Sendable {
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
 
-        let query = "result=\(outcome.label)&contactid=\(log.contactId)&issueid=\(log.issueId)&phone=\(log.phone)&via=\(via)&callerid=\(AnalyticsManager.shared.callerID)"
+        var queryParams = [
+            "result": outcome.label,
+            "contactid": log.contactId,
+            "issueid": log.issueId,
+            "phone": log.phone,
+            "via": via,
+            "callerid": AnalyticsManager.shared.callerID
+        ]
+        
+        // Add calling group if it exists
+        if let callingGroup = UserDefaults.standard.string(forKey: UserDefaultsKey.callingGroup.rawValue),
+           !callingGroup.isEmpty {
+            queryParams["group"] = callingGroup
+        }
+        
+        let query = queryParams.map { "\($0)=\($1)" }.joined(separator: "&")
         guard let data = query.data(using: .utf8) else {
             print("error creating HTTP POST body")
             return

--- a/FiveCalls/FiveCalls/UserDefaultsKey.swift
+++ b/FiveCalls/FiveCalls/UserDefaultsKey.swift
@@ -28,4 +28,5 @@ enum UserDefaultsKey : String {
     case selectIssuePath
     
     case callerID // an anoymous unique id, sometimes the old firebase userid
+    case callingGroup // a calling group is a group that tallies their calls together
 }


### PR DESCRIPTION
Fixes #445

Adds a configurable calling group id to the About screen, and sends the calling group id with a few requests. Reports are the only thing that are useful right now but possibly in the future we could return special issues for that group in fetchissues or return call counts for the group in fetchstats.

Also fixed an issue where the web-driven content on the about page was not navigating (thanks Xcode!).