### PR TITLE
Fixes checkmarks for contactids with dashes

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		D0A76F252A814786006EC2F5 /* LocationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A76F242A814786006EC2F5 /* LocationSheet.swift */; };
 		D0BA59AB1F9546510069DA58 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BA59AA1F9546510069DA58 /* NotificationService.swift */; };
 		D0BA59AF1F9546510069DA58 /* NotificationsService.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D0BA59A81F9546510069DA58 /* NotificationsService.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		D0BC8D2E2CFC23EA00560EDA /* AppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BC8D2D2CFC23EA00560EDA /* AppStateTests.swift */; };
 		D0BFE9C72A7C9434007203A3 /* ContactCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BFE9C62A7C9434007203A3 /* ContactCircle.swift */; };
 		D0BFE9C92A7C9C21007203A3 /* ContactImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BFE9C82A7C9C21007203A3 /* ContactImages.swift */; };
 		D0BFE9CB2A7DD25C007203A3 /* LocationHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BFE9CA2A7DD25C007203A3 /* LocationHeader.swift */; };
@@ -276,6 +277,7 @@
 		D0BA59AC1F9546510069DA58 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0BA59B61F9547080069DA58 /* NotificationsService.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationsService.entitlements; sourceTree = "<group>"; };
 		D0BA59B71F9547270069DA58 /* FiveCalls.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FiveCalls.entitlements; sourceTree = "<group>"; };
+		D0BC8D2D2CFC23EA00560EDA /* AppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTests.swift; sourceTree = "<group>"; };
 		D0BFE9C62A7C9434007203A3 /* ContactCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactCircle.swift; sourceTree = "<group>"; };
 		D0BFE9C82A7C9C21007203A3 /* ContactImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactImages.swift; sourceTree = "<group>"; };
 		D0BFE9CA2A7DD25C007203A3 /* LocationHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationHeader.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 			isa = PBXGroup;
 			children = (
 				B502805F1E478BC200749ED7 /* Info.plist */,
+				D0BC8D2D2CFC23EA00560EDA /* AppStateTests.swift */,
 				B50280671E478BF500749ED7 /* ContactLogsTests.swift */,
 				D0176E8A2B3343150090E6B7 /* ContactParsingTest.swift */,
 				D05EDAF52B3282F500FD94BD /* IssueParsingTest.swift */,
@@ -852,6 +855,7 @@
 				AACC2AED1E735144004B2F2B /* StreakCounterTests.swift in Sources */,
 				D0176E8B2B3343150090E6B7 /* ContactParsingTest.swift in Sources */,
 				4F3A572B2B597C8E009D4616 /* UserLocationTests.swift in Sources */,
+				D0BC8D2E2CFC23EA00560EDA /* AppStateTests.swift in Sources */,
 				D0E042662B47D06700D22647 /* IssueTests.swift in Sources */,
 				4F2178752B488CD70032D592 /* StoreTests.swift in Sources */,
 			);

--- a/FiveCalls/FiveCalls/AppState.swift
+++ b/FiveCalls/FiveCalls/AppState.swift
@@ -92,8 +92,13 @@ extension AppState {
     func issueCalledOn(issueID: Int, contactID: String) -> Bool {
         // a contact outcome is a contactid concatenated with an outcome (B0001234-contact)
         let contactOutcomesForIssue = self.issueCompletion[issueID] ?? []
+        
         let contactIDs = contactOutcomesForIssue.map { contactOutcome in
-            return String(contactOutcome.split(separator: "-").first ?? "")
+            // Split from the right to handle contact IDs that contain hyphens
+            if let lastHyphenIndex = contactOutcome.lastIndex(of: "-") {
+                return String(contactOutcome[..<lastHyphenIndex])
+            }
+            return contactOutcome
         }
 
         return contactIDs.contains(contactID)

--- a/FiveCalls/FiveCallsTests/AppStateTests.swift
+++ b/FiveCalls/FiveCallsTests/AppStateTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import FiveCalls
+
+final class AppStateTests: XCTestCase {
+    
+    var sut: AppState!
+    
+    override func setUp() {
+        super.setUp()
+        sut = AppState()
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+    
+    func testIssueCalledOn_WhenNoCompletions_ReturnsFalse() {
+        let issueID = 123
+        let contactID = "B0001234"
+        
+        let result = sut.issueCalledOn(issueID: issueID, contactID: contactID)
+        
+        XCTAssertFalse(result)
+    }
+    
+    func testIssueCalledOn_WhenContactCalledForIssue_ReturnsTrue() {
+        let issueID = 123
+        let contactID = "B0001234"
+        sut.issueCompletion = [issueID: ["\(contactID)-contacted"]]
+        
+        let result = sut.issueCalledOn(issueID: issueID, contactID: contactID)
+        
+        XCTAssertTrue(result)
+    }
+    
+    func testIssueCalledOn_WhenDifferentContactCalledForIssue_ReturnsFalse() {
+        let issueID = 123
+        let contactID = "B0001234"
+        sut.issueCompletion = [issueID: ["B0005678-contacted"]]
+        
+        let result = sut.issueCalledOn(issueID: issueID, contactID: contactID)
+        
+        XCTAssertFalse(result)
+    }
+    
+    func testIssueCalledOn_WhenContactCalledForDifferentIssue_ReturnsFalse() {
+        let issueID = 123
+        let contactID = "B0001234"
+        sut.issueCompletion = [456: ["\(contactID)-contacted"]]
+        
+        let result = sut.issueCalledOn(issueID: issueID, contactID: contactID)
+        
+        XCTAssertFalse(result)
+    }
+    
+    func testIssueCalledOn_WithMultipleOutcomes_ReturnsTrue() {
+        let issueID = 123
+        let contactID = "B0001234"
+        sut.issueCompletion = [issueID: ["B0005678-contacted", "\(contactID)-unavailable"]]
+        
+        let result = sut.issueCalledOn(issueID: issueID, contactID: contactID)
+        
+        XCTAssertTrue(result)
+    }
+
+    func testIssueCalledOn_WithHyphenatedContactID_ReturnsTrue() {
+        let issueID = 123
+        let contactID = "ca-newsom"
+        sut.issueCompletion = [issueID: ["\(contactID)-contacted"]]
+        
+        let result = sut.issueCalledOn(issueID: issueID, contactID: contactID)
+        
+        XCTAssertTrue(result)
+    }
+} 


### PR DESCRIPTION
Fixes #457

We were assuming all contactIDs had no dashes. We were wrong. Splits before the last appearing dash to get the contactid now, added some tests.