### PR TITLE
Indicate when a user has entered a split zip

### DIFF
--- a/FiveCalls/FiveCalls/Actions.swift
+++ b/FiveCalls/FiveCalls/Actions.swift
@@ -19,6 +19,7 @@ enum Action {
     case FetchContacts(UserLocation)
     case SetContacts([Contact])
     case SetDistrict(String)
+    case SetSplitDistrict(Bool)
     case SetLocation(UserLocation)
     case FetchMessages
     case SetMessages([InboxMessage])

--- a/FiveCalls/FiveCalls/AppState.swift
+++ b/FiveCalls/FiveCalls/AppState.swift
@@ -31,6 +31,7 @@ class AppState: ObservableObject, ReduxState {
     @Published var issueFetchTime: Date? = nil
     @Published var contacts: [Contact] = []
     @Published var district: String? = nil
+    @Published var isSplitDistrict: Bool = false
     @Published var location: UserLocation? {
         didSet {
             guard let location = self.location else { return }

--- a/FiveCalls/FiveCalls/ContactList.swift
+++ b/FiveCalls/FiveCalls/ContactList.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class ContactList : Decodable {
     let location: String
-    let lowAccuracy: Bool
+    let isSplit: Bool
     let state: String
     let district: String
     let representatives: [Contact]

--- a/FiveCalls/FiveCalls/FetchContactsOperation.swift
+++ b/FiveCalls/FiveCalls/FetchContactsOperation.swift
@@ -16,6 +16,7 @@ class FetchContactsOperation: BaseOperation, @unchecked Sendable {
     var httpResponse: HTTPURLResponse?
     var error: Error?
     var contacts: [Contact]?
+    var splitDistrict: Bool?
     var district: String?
 
     init(location: UserLocation, config: URLSessionConfiguration? = nil) {
@@ -70,6 +71,8 @@ class FetchContactsOperation: BaseOperation, @unchecked Sendable {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let contactList = try decoder.decode(ContactList.self, from: data)
+
+        splitDistrict = contactList.isSplit
         if contactList.generalizedLocationID != "-" {
             district = contactList.generalizedLocationID
             OneSignal.sendTag("districtID", value: contactList.generalizedLocationID)

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -115,6 +115,7 @@
 "location-error-off"                  = "Location permission is off";
 "location-error-default"              = "An error occured trying to find your location";
 "location-or"                         = "Or";
+"location-split-district"             = "This zip code is split between multiple Congressional districts, please use a zip+4 or address for best accuracy.";
 
 // outcomes
 "outcomes.contact"                    = "Made Contact";

--- a/FiveCalls/FiveCalls/LocationHeader.swift
+++ b/FiveCalls/FiveCalls/LocationHeader.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct LocationHeader: View {
     let location: UserLocation?
+    let isSplit: Bool
     let fetchingContacts: Bool
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -45,9 +46,17 @@ struct LocationHeader: View {
             VStack(alignment: .leading) {
                 Text(R.string.localizable.yourLocationIs)
                     .font(.footnote)
-                Text(location!.locationDisplay)
-                    .font(.system(.title3))
-                    .fontWeight(.medium)
+                if isSplit {
+                    Text(
+                        "\(Image(systemName: "exclamationmark.triangle")) \(location!.locationDisplay)"
+                    )
+                        .font(.system(.title3))
+                        .fontWeight(.medium)
+                } else {
+                    Text(location!.locationDisplay)
+                        .font(.system(.title3))
+                        .fontWeight(.medium)
+                }
             }
             .padding(.horizontal, usingRegularFonts() ? 15 : 5)
             .padding(.vertical, 10)
@@ -90,9 +99,17 @@ struct LocationHeader: View {
 struct LocationHeader_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            LocationHeader(location: nil, fetchingContacts: true)
-            LocationHeader(location: nil, fetchingContacts: false)
-            LocationHeader(location: UserLocation(address: "19444"), fetchingContacts: false)
+            LocationHeader(location: nil, isSplit: false, fetchingContacts: true)
+            LocationHeader(location: nil, isSplit: true, fetchingContacts: false)
+            LocationHeader(
+                location: UserLocation(address: "19444"),
+                isSplit: false, fetchingContacts: false
+            )
+                .frame(maxWidth: 250)
+            LocationHeader(
+                location: UserLocation(address: "48184"),
+                isSplit: true, fetchingContacts: false
+            )
                 .frame(maxWidth: 250)
             Spacer()
         }

--- a/FiveCalls/FiveCalls/LocationSheet.swift
+++ b/FiveCalls/FiveCalls/LocationSheet.swift
@@ -23,6 +23,15 @@ struct LocationSheet: View {
     var body: some View {
         VStack {
             VStack(alignment: .leading, spacing: 0) {
+                if store.state.isSplitDistrict {
+                    Text(
+                        "\(Image(systemName: "exclamationmark.triangle")) \(R.string.localizable.locationSplitDistrict())"
+                    )
+                        .font(.footnote)
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 35)
+                        .padding(.bottom, 10)
+                }
                 HStack {
                     HStack {
                         TextField(text: $locationText) {

--- a/FiveCalls/FiveCalls/MainHeader.swift
+++ b/FiveCalls/FiveCalls/MainHeader.swift
@@ -17,7 +17,9 @@ struct MainHeader: View {
         HStack {
             MenuView(showingWelcomeScreen: store.state.showWelcomeScreen)
 
-            LocationHeader(location: store.state.location, fetchingContacts: store.state.fetchingContacts)
+            LocationHeader(location: store.state.location,
+                           isSplit: store.state.isSplitDistrict,
+                           fetchingContacts: store.state.fetchingContacts)
                 .padding(.bottom, 10)
                 .onTapGesture {
                     showLocationSheet.toggle()

--- a/FiveCalls/FiveCalls/Middleware.swift
+++ b/FiveCalls/FiveCalls/Middleware.swift
@@ -30,8 +30,8 @@ func appMiddleware() -> Middleware<AppState> {
             reportOutcome(log: contactLog, outcome: outcome)
         case .SetGlobalCallCount, .SetIssueCallCount, .SetDonateOn, .SetIssueContactCompletion, .SetContacts, 
                 .SetFetchingContacts, .SetIssues, .SetLoadingStatsError, .SetLoadingIssuesError, .SetLoadingContactsError,
-                .GoBack, .GoToRoot, .GoToNext, .ShowWelcomeScreen, .SetDistrict, .SetMessages, .SelectMessage(_),
-                .SelectMessageIDWhenLoaded(_), .SetNavigateToInboxMessage(_):
+                .GoBack, .GoToRoot, .GoToNext, .ShowWelcomeScreen, .SetDistrict, .SetSplitDistrict, .SetMessages,
+                .SelectMessage(_), .SelectMessageIDWhenLoaded(_), .SetNavigateToInboxMessage(_):
             // no middleware actions for these, including for completeness
             break
         }
@@ -107,6 +107,9 @@ private func fetchContacts(location: UserLocation, dispatch: @escaping Dispatche
         
         if let district = operation?.district {
             dispatch(.SetDistrict(district))
+        }
+        if let split = operation?.splitDistrict {
+            dispatch(.SetSplitDistrict(split))
         }
 
         if var contacts = operation?.contacts, !contacts.isEmpty {

--- a/FiveCalls/FiveCalls/Store.swift
+++ b/FiveCalls/FiveCalls/Store.swift
@@ -64,6 +64,8 @@ class Store: ObservableObject {
             if oldDistrict != district {
                 dispatch(action: .FetchMessages)
             }
+        case let .SetSplitDistrict(splitDistrict):
+            state.isSplitDistrict = splitDistrict
         case let .SetLocation(location):
             state.location = location
         case let .SetMessages(messages):

--- a/FiveCalls/FiveCallsUITests/GET-v1-reps.json
+++ b/FiveCalls/FiveCallsUITests/GET-v1-reps.json
@@ -1,6 +1,6 @@
 {
   "location": "San Francisco",
-  "lowAccuracy": false,
+  "isSplit": false,
   "state": "CA",
   "district": "17th",
   "representatives": [


### PR DESCRIPTION
Using our new `isSplit` in the contacts response, we tell the user if they've entered a split district. They can still use it if they want!

https://github.com/user-attachments/assets/49e4006c-3ab6-414f-98ec-86d25a428afb

