### PR TITLE
Issue #466: Change photo circles colors to represent party

### DIFF
--- a/FiveCalls/FiveCalls/ContactImages.swift
+++ b/FiveCalls/FiveCalls/ContactImages.swift
@@ -19,7 +19,17 @@ func defaultImage(forContact contact: Contact) -> UIImage {
     UIGraphicsBeginImageContext(CGSize(width: 256, height: 256))
     
     let colorIndex = abs(Int(contact.id.hash)) % sampleColors.count
-    sampleColors[colorIndex].setFill()
+    
+    var partyColor: UIColor {
+        switch contact.party {
+        case "Democrat": return hexStringToColor(hexString: "#4C72A9")
+        case "Republican": return hexStringToColor(hexString: "#A94C47")
+        case "Independent": return hexStringToColor(hexString: "#9063CD")
+        default: return sampleColors[colorIndex]
+        }
+    }
+    
+    partyColor.setFill()
     
     let context = UIGraphicsGetCurrentContext()
     context?.fill([CGRect(origin: .zero, size: CGSize(width: 256, height: 256))])


### PR DESCRIPTION
- Addresses https://github.com/5calls/ios/issues/466
- When a photo does not load or is unavailable, the respective party color is displayed instead of the sample colors.
- If no party information is available, the fallback remains the sample colors.
- Used soft tones of red, blue, and purple to match the aesthetic of the sample colors, but this can be changed if needed.


https://github.com/user-attachments/assets/d64ed8a6-2b8e-4353-8408-0268a8dffe90

Example of person with no party affiliation.

<img src="https://github.com/user-attachments/assets/517e7339-9e52-4fa1-9c2f-cecfe6d451b5" width="300">
