### PR TITLE
Issue #465: fix async image loading issue

### DIFF
--- a/FiveCalls/FiveCalls/IssueDetail.swift
+++ b/FiveCalls/FiveCalls/IssueDetail.swift
@@ -70,10 +70,6 @@ struct IssueDetail: View {
             .padding(.horizontal)
         }
         .id(forceRefreshID)
-        .onAppear {
-            // Force refresh id so that async images can load. See https://github.com/5calls/ios/issues/465
-            forceRefreshID = UUID()
-        }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -96,6 +92,9 @@ struct IssueDetail: View {
             Spacer()
         }
         .onAppear {
+            // Force refresh id so that async images can load. See https://github.com/5calls/ios/issues/465
+            forceRefreshID = UUID()
+            
             AnalyticsManager.shared.trackPageview(path: "/issue/\(issue.slug)/")
         }
     }

--- a/FiveCalls/FiveCalls/IssueDetail.swift
+++ b/FiveCalls/FiveCalls/IssueDetail.swift
@@ -15,6 +15,7 @@ struct IssueDetail: View {
     let contacts: [Contact]
     
     @State var showLocationSheet = false
+    @State private var forceRefreshID = UUID()
     
     var body: some View {
         ScrollView {
@@ -67,6 +68,11 @@ struct IssueDetail: View {
                 }
             }
             .padding(.horizontal)
+        }
+        .id(forceRefreshID)
+        .onAppear {
+            // Force refresh id so that async images can load. See https://github.com/5calls/ios/issues/465
+            forceRefreshID = UUID()
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {


### PR DESCRIPTION
Fixes https://github.com/5calls/ios/issues/465

It seems this bug appears only when the app is in a compact size class (on an iPhone or a smaller iPad window). On a full-screen iPad, when both columns of the split view are visible, it does not occur.

Based on additional testing in a standalone playground, it seems this is just a bug with AsyncImage in a split view context. (https://gist.github.com/raysj9/5f1b89fff62b5d8145323eec21937d21)

This workaround forces the issue detail view to refresh, which allows the Async images to load reliably. I'm thinking the only other way around this would be to find another way to load images without using a standard Swiftui async image.

Before: 

https://github.com/user-attachments/assets/f56c4317-52f1-46d6-bf97-bec329776b49



After:

https://github.com/user-attachments/assets/47152b00-ed95-430d-800a-666431d91d64

