### PR TITLE
Adds issue search on the dashboard

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		D07D7C242B3F48A1004721B3 /* ProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05EDAF32B3280D700FD94BD /* ProtocolMock.swift */; };
 		D07D7C282B3F75C2004721B3 /* GET-v1-issues-UI.json in Resources */ = {isa = PBXBuildFile; fileRef = D07D7C272B3F75C2004721B3 /* GET-v1-issues-UI.json */; };
 		D07D7C2D2B3FE530004721B3 /* GET-v1-reps-UI.json in Resources */ = {isa = PBXBuildFile; fileRef = D07D7C2C2B3FE530004721B3 /* GET-v1-reps-UI.json */; };
+		D07ECA072E08675E00948BEC /* LogSearchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07ECA062E08675E00948BEC /* LogSearchOperation.swift */; };
 		D082961C2A7BFE04005B002A /* Numbered.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082961B2A7BFE04005B002A /* Numbered.swift */; };
 		D0899DC82BF68A6900761577 /* PreviewMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0899DC72BF68A6900761577 /* PreviewMessages.swift */; };
 		D08A9E7A2BA7DDF9006D3DCC /* FetchMessagesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08A9E792BA7DDF9006D3DCC /* FetchMessagesOperation.swift */; };
@@ -258,6 +259,7 @@
 		D07829762A7B3795001EE5DB /* PreviewContacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewContacts.swift; sourceTree = "<group>"; };
 		D07D7C272B3F75C2004721B3 /* GET-v1-issues-UI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "GET-v1-issues-UI.json"; sourceTree = "<group>"; };
 		D07D7C2C2B3FE530004721B3 /* GET-v1-reps-UI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "GET-v1-reps-UI.json"; sourceTree = "<group>"; };
+		D07ECA062E08675E00948BEC /* LogSearchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSearchOperation.swift; sourceTree = "<group>"; };
 		D082961B2A7BFE04005B002A /* Numbered.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Numbered.swift; sourceTree = "<group>"; };
 		D0899DC72BF68A6900761577 /* PreviewMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMessages.swift; sourceTree = "<group>"; };
 		D08A9E792BA7DDF9006D3DCC /* FetchMessagesOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchMessagesOperation.swift; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 		B5E7626F1E40D74900D63D62 /* Operations */ = {
 			isa = PBXGroup;
 			children = (
+				D07ECA062E08675E00948BEC /* LogSearchOperation.swift */,
 				B5E7625A1E4037B400D63D62 /* BaseOperation.swift */,
 				B5E762581E40374600D63D62 /* FetchStatsOperation.swift */,
 				B5E762721E40DC5800D63D62 /* FetchIssuesOperation.swift */,
@@ -885,6 +888,7 @@
 				D0312DD82A84A27F00F58F6B /* UserLocation.swift in Sources */,
 				B5E7626B1E40D6DD00D63D62 /* Contact.swift in Sources */,
 				B5E762651E40480300D63D62 /* UserDefaultsKey.swift in Sources */,
+				D07ECA072E08675E00948BEC /* LogSearchOperation.swift in Sources */,
 				D029C6D01F6F42EA00E56CC7 /* Outcome.swift in Sources */,
 				B5D5C95A1E441FEC00C80D5F /* IssuesManager.swift in Sources */,
 				D0BFE9CB2A7DD25C007203A3 /* LocationHeader.swift in Sources */,

--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		D07D7C282B3F75C2004721B3 /* GET-v1-issues-UI.json in Resources */ = {isa = PBXBuildFile; fileRef = D07D7C272B3F75C2004721B3 /* GET-v1-issues-UI.json */; };
 		D07D7C2D2B3FE530004721B3 /* GET-v1-reps-UI.json in Resources */ = {isa = PBXBuildFile; fileRef = D07D7C2C2B3FE530004721B3 /* GET-v1-reps-UI.json */; };
 		D07ECA072E08675E00948BEC /* LogSearchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07ECA062E08675E00948BEC /* LogSearchOperation.swift */; };
+		D07ECA0E2E08698F00948BEC /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07ECA0D2E08698F00948BEC /* SearchBar.swift */; };
 		D082961C2A7BFE04005B002A /* Numbered.swift in Sources */ = {isa = PBXBuildFile; fileRef = D082961B2A7BFE04005B002A /* Numbered.swift */; };
 		D0899DC82BF68A6900761577 /* PreviewMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0899DC72BF68A6900761577 /* PreviewMessages.swift */; };
 		D08A9E7A2BA7DDF9006D3DCC /* FetchMessagesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08A9E792BA7DDF9006D3DCC /* FetchMessagesOperation.swift */; };
@@ -260,6 +261,7 @@
 		D07D7C272B3F75C2004721B3 /* GET-v1-issues-UI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "GET-v1-issues-UI.json"; sourceTree = "<group>"; };
 		D07D7C2C2B3FE530004721B3 /* GET-v1-reps-UI.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "GET-v1-reps-UI.json"; sourceTree = "<group>"; };
 		D07ECA062E08675E00948BEC /* LogSearchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogSearchOperation.swift; sourceTree = "<group>"; };
+		D07ECA0D2E08698F00948BEC /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		D082961B2A7BFE04005B002A /* Numbered.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Numbered.swift; sourceTree = "<group>"; };
 		D0899DC72BF68A6900761577 /* PreviewMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewMessages.swift; sourceTree = "<group>"; };
 		D08A9E792BA7DDF9006D3DCC /* FetchMessagesOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchMessagesOperation.swift; sourceTree = "<group>"; };
@@ -528,6 +530,7 @@
 		D0002E142A9DB2F70098973F /* View Components */ = {
 			isa = PBXGroup;
 			children = (
+				D07ECA0D2E08698F00948BEC /* SearchBar.swift */,
 				D00E8B682CF056A70028F935 /* NewsletterSignup.swift */,
 				4F4868BA2AC3A3B400E1733A /* AboutListItem.swift */,
 				D0BFE9C62A7C9434007203A3 /* ContactCircle.swift */,
@@ -890,6 +893,7 @@
 				B5E762651E40480300D63D62 /* UserDefaultsKey.swift in Sources */,
 				D07ECA072E08675E00948BEC /* LogSearchOperation.swift in Sources */,
 				D029C6D01F6F42EA00E56CC7 /* Outcome.swift in Sources */,
+				D07ECA0E2E08698F00948BEC /* SearchBar.swift in Sources */,
 				B5D5C95A1E441FEC00C80D5F /* IssuesManager.swift in Sources */,
 				D0BFE9CB2A7DD25C007203A3 /* LocationHeader.swift in Sources */,
 				2732D7C71E4300F300F149EF /* NotificationNames.swift in Sources */,

--- a/FiveCalls/FiveCalls/Actions.swift
+++ b/FiveCalls/FiveCalls/Actions.swift
@@ -35,4 +35,5 @@ enum Action {
     case GoToRoot
     case GoToNext(Issue, [Contact])
     case SetMissingReps([String])
+    case LogSearch(String)
 }

--- a/FiveCalls/FiveCalls/Dashboard.swift
+++ b/FiveCalls/FiveCalls/Dashboard.swift
@@ -16,6 +16,7 @@ struct Dashboard: View {
     @Binding var selectedIssue: Issue?
 
     @State var showAllIssues = false
+    @State var searchText = ""
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -59,8 +60,36 @@ struct Dashboard: View {
                     .accessibilityAddTraits(.isHeader)
                     .padding(.horizontal, 16)
             }
+            
+            // Search bar
+            HStack {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundColor(.secondary)
+                    
+                    TextField("Search all issues...", text: $searchText)
+                        .textFieldStyle(PlainTextFieldStyle())
+                        .onSubmit {}
+                    
+                    if !searchText.isEmpty {
+                        Button {
+                            searchText = ""
+                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(Color(.systemGray6))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 8)
 
-            IssuesList(store: store, selectedIssue: $selectedIssue, showAllIssues: $showAllIssues)
+            IssuesList(store: store, selectedIssue: $selectedIssue, showAllIssues: $showAllIssues, searchText: $searchText)
         }
         .navigationBarHidden(true)
         .onAppear() {
@@ -151,19 +180,54 @@ struct IssuesList: View {
     @ObservedObject var store: Store
     @Binding var selectedIssue: Issue?
     @Binding var showAllIssues: Bool
+    @Binding var searchText: String
+    
+    var isSearching: Bool {
+        searchText.count >= 3
+    }
 
     var allIssues: [Issue] {
-        if showAllIssues {
-            return store.state.issues
+        let baseIssues: [Issue]
+        
+        if isSearching {
+            // When searching, search all issues regardless of active status
+            let filteredIssues = store.state.issues.filter { issue in
+                issue.name.localizedCaseInsensitiveContains(searchText) ||
+                issue.reason.localizedCaseInsensitiveContains(searchText) ||
+                issue.script.localizedCaseInsensitiveContains(searchText) ||
+                issue.slug.localizedCaseInsensitiveContains(searchText) ||
+                issue.categories.contains { category in
+                    category.name.localizedCaseInsensitiveContains(searchText)
+                }
+            }
+            
+            // Sort results with name matches first
+            baseIssues = filteredIssues.sorted { issue1, issue2 in
+                let issue1NameMatch = issue1.name.localizedCaseInsensitiveContains(searchText)
+                let issue2NameMatch = issue2.name.localizedCaseInsensitiveContains(searchText)
+                
+                if issue1NameMatch && !issue2NameMatch {
+                    return true // issue1 comes first
+                } else if !issue1NameMatch && issue2NameMatch {
+                    return false // issue2 comes first
+                } else {
+                    return false
+                }
+            }
+        } else if showAllIssues {
+            baseIssues = store.state.issues
         } else {
-            return store.state.issues.filter({ $0.active })
+            baseIssues = store.state.issues.filter({ $0.active })
         }
+        
+        return baseIssues
     }
 
     private var categorizedIssues: [CategorizedIssuesViewModel] {
         var categoryViewModels = Set<CategorizedIssuesViewModel>()
-        if !showAllIssues {
-            // if we're showing the default list, make fake categories to preserve the json order. The category names don't matter because we don't show them on the default list
+        
+        if isSearching || !showAllIssues {
+            // For search results or default view, make fake categories to preserve order and show flat list
             return allIssues.map({ CategorizedIssuesViewModel(category: Category(name: "\($0.id)"), issues: [$0]) })
         }
 
@@ -190,12 +254,12 @@ struct IssuesList: View {
                         .listRowSeparatorTint(.fivecallsDarkGray)
                     }
                 } header: {
-                    if showAllIssues {
+                    if showAllIssues && !isSearching {
                         Text(section.name.uppercased()).font(.headline)
                             .foregroundStyle(.fivecallsDarkGray)
                     }
                 } footer: {
-                    if section == categorizedIssues.last {
+                    if section == categorizedIssues.last && !isSearching {
                         Button {
                             showAllIssues.toggle()
                             if let issueID = categorizedIssues.first?.issues.first?.id {

--- a/FiveCalls/FiveCalls/Dashboard.swift
+++ b/FiveCalls/FiveCalls/Dashboard.swift
@@ -17,9 +17,6 @@ struct Dashboard: View {
 
     @State var showAllIssues = false
     @State var searchText = ""
-    @FocusState private var isSearchFocused: Bool
-    @State private var searchWorkItem: DispatchWorkItem?
-    @State private var hasLoggedCurrentSearch = false
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -64,64 +61,7 @@ struct Dashboard: View {
                     .padding(.horizontal, 16)
             }
             
-            // Search bar
-            HStack {
-                HStack {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundColor(.secondary)
-                    
-                    TextField(R.string.localizable.searchIssues(), text: $searchText)
-                        .textFieldStyle(PlainTextFieldStyle())
-                        .focused($isSearchFocused)
-                        .onChange(of: searchText) { newValue in
-                            if newValue.count > 30 {
-                                searchText = String(newValue.prefix(30))
-                                return
-                            }
-                            
-                            // Cancel previous search logging work item
-                            searchWorkItem?.cancel()
-                            
-                            // Reset logging flag when search is cleared
-                            if newValue.isEmpty {
-                                hasLoggedCurrentSearch = false
-                                return
-                            }
-                            
-                            // Only log once per search session (until cleared) for searches >= 3 characters
-                            if newValue.count >= 3 && !hasLoggedCurrentSearch {
-                                let workItem = DispatchWorkItem {
-                                    // Double-check that we haven't logged yet during the delay
-                                    if !hasLoggedCurrentSearch {
-                                        hasLoggedCurrentSearch = true
-                                        store.dispatch(action: .LogSearch(newValue))
-                                    }
-                                }
-                                searchWorkItem = workItem
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: workItem)
-                            }
-                        }
-                        .onSubmit {}
-                    
-                    if !searchText.isEmpty {
-                        Button {
-                            searchText = ""
-                            isSearchFocused = false
-                            hasLoggedCurrentSearch = false
-                            searchWorkItem?.cancel()
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .background(Color(.systemGray6))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-            }
-            .padding(.horizontal, 16)
-            .padding(.bottom, 8)
+            SearchBar(searchText: $searchText)
 
             IssuesList(store: store, selectedIssue: $selectedIssue, showAllIssues: $showAllIssues, searchText: $searchText)
         }

--- a/FiveCalls/FiveCalls/Dashboard.swift
+++ b/FiveCalls/FiveCalls/Dashboard.swift
@@ -17,6 +17,7 @@ struct Dashboard: View {
 
     @State var showAllIssues = false
     @State var searchText = ""
+    @FocusState private var isSearchFocused: Bool
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
@@ -67,14 +68,15 @@ struct Dashboard: View {
                     Image(systemName: "magnifyingglass")
                         .foregroundColor(.secondary)
                     
-                    TextField("Search all issues...", text: $searchText)
+                    TextField(R.string.localizable.searchIssues(), text: $searchText)
                         .textFieldStyle(PlainTextFieldStyle())
+                        .focused($isSearchFocused)
                         .onSubmit {}
                     
                     if !searchText.isEmpty {
                         Button {
                             searchText = ""
-                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                            isSearchFocused = false
                         } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundColor(.secondary)

--- a/FiveCalls/FiveCalls/Dashboard.swift
+++ b/FiveCalls/FiveCalls/Dashboard.swift
@@ -71,6 +71,11 @@ struct Dashboard: View {
                     TextField(R.string.localizable.searchIssues(), text: $searchText)
                         .textFieldStyle(PlainTextFieldStyle())
                         .focused($isSearchFocused)
+                        .onChange(of: searchText) { newValue in
+                            if newValue.count > 30 {
+                                searchText = String(newValue.prefix(30))
+                            }
+                        }
                         .onSubmit {}
                     
                     if !searchText.isEmpty {

--- a/FiveCalls/FiveCalls/IssueSplitView.swift
+++ b/FiveCalls/FiveCalls/IssueSplitView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct IssueSplitView: View {
     @EnvironmentObject var store: Store
+    @Environment(\.horizontalSizeClass) private var originalSizeClass
     
     var body: some View {
         TabView(selection: $store.state.selectedTab) {
@@ -43,11 +44,15 @@ struct IssueSplitView: View {
             .navigationSplitViewStyle(.balanced)
             .tabItem({ Label(R.string.localizable.tabTopics(), systemImage: "phone.bubble.fill" ) })
             .tag("topics")
+            // Set the inner size class for the navigation stack back to whatever it was originally since we override it for old tab bar behavior below
+            .environment(\.horizontalSizeClass, originalSizeClass)
+            .toolbar(.visible, for: .tabBar)
             
             InboxView()
                 .tabItem({ Label(R.string.localizable.tabReps(), systemImage: "person.crop.circle.fill.badge.checkmark") })
                 .tag("inbox")
-        }
+        }// the new TabBar style in iOS 18 does not work well with this style, for now override the size class so it uses the old style on iPadOS
+        .environment(\.horizontalSizeClass, .compact)
     }
 }
 

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -46,6 +46,7 @@
 "menu-tip-message"                    = "Your Impact and About now reside in Settings menu along with Reminders";
 "more-issues-title"                   = "More Issues";
 "less-issues-title"                   = "Fewer Issues";
+"search-issues"                       = "Search all issues...";
 
 // scheduled reminders
 "scheduled-reminder-alert-body"       = "Tap here to open 5 Calls and get started";

--- a/FiveCalls/FiveCalls/Localizable.strings
+++ b/FiveCalls/FiveCalls/Localizable.strings
@@ -47,6 +47,8 @@
 "more-issues-title"                   = "More Issues";
 "less-issues-title"                   = "Fewer Issues";
 "search-issues"                       = "Search all issues...";
+"search-no-results-title"             = "No issues found";
+"search-no-results-message"           = "Try a different search term";
 
 // scheduled reminders
 "scheduled-reminder-alert-body"       = "Tap here to open 5 Calls and get started";

--- a/FiveCalls/FiveCalls/LogSearchOperation.swift
+++ b/FiveCalls/FiveCalls/LogSearchOperation.swift
@@ -2,18 +2,15 @@
 //  LogSearchOperation.swift
 //  FiveCalls
 //
-//  Created by Claude on 6/22/25.
+//  Created by Nick O'Neill on 6/22/25.
 //  Copyright © 2025 5calls. All rights reserved.
 //
 
 import Foundation
 
 class LogSearchOperation: BaseOperation, @unchecked Sendable {
-    
-    //Input properties
     var searchQuery: String
     
-    //Output properties
     var httpResponse: HTTPURLResponse?
     var error: Error?
     
@@ -36,13 +33,7 @@ class LogSearchOperation: BaseOperation, @unchecked Sendable {
         var requestBody: [String: Any] = [
             "query": searchQuery
         ]
-        
-        // Add calling group if it exists
-        if let callingGroup = UserDefaults.standard.string(forKey: UserDefaultsKey.callingGroup.rawValue),
-           !callingGroup.isEmpty {
-            requestBody["group"] = callingGroup
-        }
-        
+                
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: requestBody, options: [])
             request.httpBody = jsonData

--- a/FiveCalls/FiveCalls/LogSearchOperation.swift
+++ b/FiveCalls/FiveCalls/LogSearchOperation.swift
@@ -1,0 +1,73 @@
+//
+//  LogSearchOperation.swift
+//  FiveCalls
+//
+//  Created by Claude on 6/22/25.
+//  Copyright © 2025 5calls. All rights reserved.
+//
+
+import Foundation
+
+class LogSearchOperation: BaseOperation, @unchecked Sendable {
+    
+    //Input properties
+    var searchQuery: String
+    
+    //Output properties
+    var httpResponse: HTTPURLResponse?
+    var error: Error?
+    
+    init(searchQuery: String) {
+        self.searchQuery = searchQuery
+    }
+    
+    var url: URL {
+        return URL(string: "https://api.5calls.org/v1/users/search")!
+    }
+
+    override func execute() {
+        let config = URLSessionConfiguration.default
+        let session = URLSession(configuration: config)
+
+        var request = buildRequest(forURL: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        var requestBody: [String: Any] = [
+            "query": searchQuery
+        ]
+        
+        // Add calling group if it exists
+        if let callingGroup = UserDefaults.standard.string(forKey: UserDefaultsKey.callingGroup.rawValue),
+           !callingGroup.isEmpty {
+            requestBody["group"] = callingGroup
+        }
+        
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: requestBody, options: [])
+            request.httpBody = jsonData
+        } catch {
+            print("Error creating JSON body for search log: \(error)")
+            self.error = error
+            self.finish()
+            return
+        }
+        
+        let task = session.dataTask(with: request) { (data, response, error) in
+            if let e = error {
+                self.error = e
+                print("Error logging search query: \(e)")
+            } else {
+                let http = response as! HTTPURLResponse
+                self.httpResponse = http
+                if http.statusCode == 200 {
+                    print("Search query logged successfully")
+                } else {
+                    print("Search query logging failed with status: \(http.statusCode)")
+                }
+            }
+            self.finish()
+        }
+        task.resume()
+    }
+}

--- a/FiveCalls/FiveCalls/Middleware.swift
+++ b/FiveCalls/FiveCalls/Middleware.swift
@@ -29,6 +29,8 @@ func appMiddleware() -> Middleware<AppState> {
             }
             AnalyticsManager.shared.trackEvent(name: "Outcome-\(outcome.status)", path: "/issue/\(issue.slug)/")
             reportOutcome(log: contactLog, outcome: outcome)
+        case let .LogSearch(searchQuery):
+            logSearch(searchQuery: searchQuery)
         case .SetGlobalCallCount, .SetIssueCallCount, .SetDonateOn, .SetIssueContactCompletion, .SetContacts, 
                 .SetFetchingContacts, .SetIssues, .SetLoadingStatsError, .SetLoadingIssuesError, .SetLoadingContactsError,
                 .GoBack, .GoToRoot, .GoToNext, .ShowWelcomeScreen, .SetDistrict, .SetSplitDistrict, .SetMessages, .SetMissingReps,
@@ -167,6 +169,11 @@ private func fetchMessages(state: AppState, dispatch: @escaping Dispatcher) {
 private func reportOutcome(log: ContactLog, outcome: Outcome) {
     // we don't actually care about the result of this so no need to set the callback
     OperationQueue.main.addOperation(ReportOutcomeOperation(log: log, outcome: outcome))
+}
+
+private func logSearch(searchQuery: String) {
+    // we don't actually care about the result of this so no need to set the callback
+    OperationQueue.main.addOperation(LogSearchOperation(searchQuery: searchQuery))
 }
 
 enum MiddlewareError: Error {

--- a/FiveCalls/FiveCalls/SearchBar.swift
+++ b/FiveCalls/FiveCalls/SearchBar.swift
@@ -1,0 +1,86 @@
+//
+//  SearchBar.swift
+//  FiveCalls
+//
+//  Created by Nick O'Neill on 6/22/25.
+//  Copyright © 2025 5calls. All rights reserved.
+//
+
+import SwiftUI
+
+struct SearchBar: View {
+    @Binding var searchText: String
+    @EnvironmentObject var store: Store
+    
+    @FocusState private var isSearchFocused: Bool
+    @State private var searchWorkItem: DispatchWorkItem?
+    @State private var hasLoggedCurrentSearch = false
+    
+    var body: some View {
+        HStack {
+            HStack {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.secondary)
+                
+                TextField(R.string.localizable.searchIssues(), text: $searchText)
+                    .textFieldStyle(PlainTextFieldStyle())
+                    .focused($isSearchFocused)
+                    .onChange(of: searchText) { newValue in
+                        handleSearchTextChange(newValue)
+                    }
+                    .onSubmit {}
+                
+                if !searchText.isEmpty {
+                    Button {
+                        clearSearch()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(Color(.systemGray6))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+    }
+    
+    private func handleSearchTextChange(_ newValue: String) {
+        if newValue.count > 30 {
+            searchText = String(newValue.prefix(30))
+            return
+        }
+        
+        // Cancel previous search logging work item
+        searchWorkItem?.cancel()
+        
+        // Reset logging flag when search is cleared
+        if newValue.isEmpty {
+            hasLoggedCurrentSearch = false
+            return
+        }
+        
+        // Only log once per search session (until cleared) for searches >= 3 characters
+        if newValue.count >= 3 && !hasLoggedCurrentSearch {
+            let workItem = DispatchWorkItem {
+                // Double-check that we haven't logged yet during the delay
+                if !hasLoggedCurrentSearch {
+                    hasLoggedCurrentSearch = true
+                    store.dispatch(action: .LogSearch(newValue))
+                }
+            }
+            searchWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: workItem)
+        }
+    }
+    
+    private func clearSearch() {
+        searchText = ""
+        isSearchFocused = false
+        hasLoggedCurrentSearch = false
+        searchWorkItem?.cancel()
+    }
+}

--- a/FiveCalls/FiveCalls/Store.swift
+++ b/FiveCalls/FiveCalls/Store.swift
@@ -126,7 +126,10 @@ class Store: ObservableObject {
            } else {
                state.issueRouter.path.append(IssueDoneNavModel(issue: issue, type: "done"))
            }
-        case .FetchStats, .FetchIssues, .FetchContacts(_), .FetchMessages, .ReportOutcome(_, _, _):
+        case .FetchStats, .FetchIssues,
+                .FetchContacts(_), .FetchMessages,
+                .ReportOutcome(_, _, _),
+                .LogSearch(_):
             // handled in middleware
             break
         }


### PR DESCRIPTION
Folks frequently contact us to ask for issues that are already in the list (sometimes just on the all issues page). This gives users a way to search issues above the topic list.

Searches title, description, script and slug. Prioritizes title matches at the top of the list.

Fixes https://github.com/5calls/5calls/issues/24 for iOS