### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# Top-level configuration file
+root = true
+
+# Default: spaces, 2-space indentation
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Swift
+[*.swift]
+indent_size = 4
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Xcode has supported EditorConfig files for a few years now. It makes it easier for those of us who have different indent spacings across projects and languages.