### PR TITLE
Remove dead code

### DIFF
--- a/FiveCalls/FiveCalls/IssueDetail.swift
+++ b/FiveCalls/FiveCalls/IssueDetail.swift
@@ -23,8 +23,7 @@ struct IssueDetail: View {
     
     // vacancies for both targeted and irrelevant contacts
     var vacantAreas: [String] {
-        let irrelevantAreas = Set(irrelevantContacts.map { $0.area })
-        return store.state.missingReps.filter { issue.contactAreas.contains($0) || $0 == issue.irrelevantContactArea() }
+        store.state.missingReps.filter { issue.contactAreas.contains($0) || $0 == issue.irrelevantContactArea() }
     }
 
     var body: some View {


### PR DESCRIPTION
Xcode flagged an unused variable, and raised a warning. It may have been left behind following a refactoring.