### PR TITLE
Handle multiple vacant senators

### DIFF
--- a/FiveCalls/FiveCalls/IssueDetail.swift
+++ b/FiveCalls/FiveCalls/IssueDetail.swift
@@ -144,14 +144,15 @@ struct IssueDetail: View {
     }
     
     private var vacantRepsList: some View {
-        ForEach(vacantAreas, id: \.self) { area in
-            let contact = Contact(area: area, name: R.string.localizable.vacantSeatTitle())
+        ForEach(vacantAreas.numbered(), id: \.element) { contact in
+            let area = contact.element
+            let contactItem = Contact(area: area, name: R.string.localizable.vacantSeatTitle())
             let note = R.string.localizable.vacantSeatMessage(area)
-            
-            ContactListItem(contact: contact, contactNote: note)
+
+            ContactListItem(contact: contactItem, contactNote: note)
                 .opacity(0.4)
             
-            if area != vacantAreas.last {
+            if contact.number < vacantAreas.count - 1 {
                 Divider()
             }
         }

--- a/FiveCalls/FiveCalls/Middleware.swift
+++ b/FiveCalls/FiveCalls/Middleware.swift
@@ -130,8 +130,9 @@ private func fetchContacts(location: UserLocation, dispatch: @escaping Dispatche
             if houseReps.count < 1 {
                 missingReps.append("US House")
             }
-            if senateReps.count < 2 {
-                missingReps.append("US Senate")
+            let missingCount = 2 - senateReps.count
+            if missingCount > 0 {
+                missingReps.append(contentsOf: Array(repeating: "US Senate", count: missingCount))
             }
             dispatch(.SetMissingReps(missingReps))
             dispatch(.SetContacts(contacts))


### PR DESCRIPTION
This handles the rare case where there are multiple Senate vacancies. For DC, on both iOS and web, the Senate seats are displaying as vacant since there are none. On iOS, it shows one vacancy instead of two (which still isn't the best way to describe the DC situation). This will make the behavior consistent with the web.

Web
<img src="https://github.com/user-attachments/assets/4a3c3ee0-34d9-49d8-98bd-6cea6333e35b" width="300">

Before
<img src="https://github.com/user-attachments/assets/5e3d9a8e-d010-448c-9df6-9e6116c9a228" width="300">

After
<img src="https://github.com/user-attachments/assets/dc6aded9-0e17-4875-9310-187b7487e34a" width="300">