### PR TITLE
added non-active state issues on more page

### DIFF
--- a/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
+++ b/FiveCalls/FiveCalls.xcodeproj/project.pbxproj
@@ -812,7 +812,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				ONE_SIGNAL_APP_ID = "5fd4ca41-9f6c-4149-a312-ae3e71b35c0e";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.fivecalls.FiveCalls-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -845,7 +845,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				ONE_SIGNAL_APP_ID = "5fd4ca41-9f6c-4149-a312-ae3e71b35c0e";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.fivecalls.FiveCalls-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -915,7 +915,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.fivecalls.FiveCalls-ios.NotificationsService";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -941,7 +941,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.3.0;
+				MARKETING_VERSION = 2.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.fivecalls.FiveCalls-ios.NotificationsService";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/FiveCalls/FiveCalls/DashboardFeature/Dashboard.swift
+++ b/FiveCalls/FiveCalls/DashboardFeature/Dashboard.swift
@@ -190,14 +190,25 @@ struct IssuesList: View {
     }
 
     private var categorizedIssues: [CategorizedIssuesViewModel] {
-        var categoryViewModels = Set<CategorizedIssuesViewModel>()
-
         if isSearching || !showAllIssues {
             // For search results or default view, make fake categories to preserve order and show flat list
             return allIssues.map { CategorizedIssuesViewModel(category: Category(name: "\($0.id)"), issues: [$0]) }
         }
 
-        for issue in allIssues {
+        var result: [CategorizedIssuesViewModel] = []
+
+        // Separate state-specific issues into their own category with the state name
+        let stateIssues = allIssues.filter { $0.isStateSpecific }
+        let nonStateIssues = allIssues.filter { !$0.isStateSpecific }
+
+        if !stateIssues.isEmpty {
+            let stateName = stateIssues.first?.stateNameFromAbbreviation ?? "State"
+            result.append(CategorizedIssuesViewModel(category: Category(name: stateName), issues: stateIssues))
+        }
+
+        // Build regular categories from non-state issues only
+        var categoryViewModels = Set<CategorizedIssuesViewModel>()
+        for issue in nonStateIssues {
             for category in issue.categories {
                 if let categorized = categoryViewModels.first(where: { $0.category == category }) {
                     categorized.issues.append(issue)
@@ -206,7 +217,9 @@ struct IssuesList: View {
                 }
             }
         }
-        return Array(categoryViewModels).sorted(by: { $0.category < $1.category })
+        result.append(contentsOf: Array(categoryViewModels).sorted(by: { $0.category < $1.category }))
+
+        return result
     }
 
     var body: some View {


### PR DESCRIPTION
For state issues marked non "active" (i.e. how we decide what is on the front page), show them on all issues at the top with the state header.

<img width="501" height="579" alt="Screenshot 2026-02-07 at 3 31 07 PM" src="https://github.com/user-attachments/assets/edae458d-9261-47a0-b32d-2eb9ee1f027f" />
