### PR TITLE
Post a referral callback when following a ref url, like the web

### DIFF
--- a/FiveCalls/FiveCalls/AppFeature/AppDelegate.swift
+++ b/FiveCalls/FiveCalls/AppFeature/AppDelegate.swift
@@ -26,11 +26,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_: UIApplication, continue userActivity: NSUserActivity, restorationHandler _: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb else {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL else {
             return false
         }
 
+        handleReferral(in: url)
+
         return true
+    }
+
+    private func handleReferral(in url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let ref = components.queryItems?.first(where: { $0.name == "ref" })?.value,
+              !ref.isEmpty else {
+            return
+        }
+
+        OperationQueue.main.addOperation(PostReferralOperation(ref: ref, path: url.path))
     }
 
     func oneSignalStartup(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {

--- a/FiveCalls/FiveCalls/Operations/PostReferralOperation.swift
+++ b/FiveCalls/FiveCalls/Operations/PostReferralOperation.swift
@@ -1,0 +1,55 @@
+// Copyright 5calls. All rights reserved. See LICENSE for details.
+
+import Foundation
+
+class PostReferralOperation: BaseOperation, @unchecked Sendable {
+    var ref: String
+    var path: String
+
+    var httpResponse: HTTPURLResponse?
+    var error: Error?
+
+    init(ref: String, path: String) {
+        self.ref = ref
+        self.path = path
+    }
+
+    var url: URL {
+        URL(string: "https://api.5calls.org/v1/users/refs")!
+    }
+
+    override func execute() {
+        let config = URLSessionConfiguration.default
+        let session = URLSession(configuration: config)
+
+        var request = buildRequest(forURL: url)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "ref", value: ref),
+            URLQueryItem(name: "meta", value: ""),
+            URLQueryItem(name: "path", value: path),
+            URLQueryItem(name: "cid", value: AnalyticsManager.shared.callerID),
+        ]
+        request.httpBody = components.percentEncodedQuery?.data(using: .utf8)
+
+        let task = session.dataTask(with: request) { _, response, error in
+            if let e = error {
+                self.error = e
+                print("Error posting referral: \(e)")
+            } else {
+                let http = response as! HTTPURLResponse
+                self.httpResponse = http
+                if http.statusCode == 200 {
+                    print("Referral posted successfully")
+                } else {
+                    print("Referral post failed with status: \(http.statusCode)")
+                }
+            }
+            self.finish()
+        }
+        task.resume()
+    }
+}


### PR DESCRIPTION
Used for linking anonymous caller ids to their arrival method. Not currently used for mobile.

We may want to give the research users a way to connect their accounts to their surveys via this method in the future.